### PR TITLE
feat/object segmentation

### DIFF
--- a/backend/stages/object_segmentation.py
+++ b/backend/stages/object_segmentation.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, Callable, List
@@ -1081,12 +1082,21 @@ class ObjectSegmentationStage:
         start_time = time.perf_counter()
 
         try:
-            # Use directory path - SAM-2 loads frames on demand
-            inference_state = self.video_predictor.init_state(
-                video_path=str(frames_dir),
-                offload_video_to_cpu=self.config.get("offload_video_to_cpu", False),
-                offload_state_to_cpu=self.config.get("offload_state_to_cpu", False),
+            # Use autocast for BFloat16 compatibility with SAM-2 video predictor
+            # See: https://github.com/facebookresearch/sam2/issues/577
+            autocast_ctx = (
+                torch.autocast("cuda", dtype=torch.bfloat16)
+                if self.device == "cuda"
+                else nullcontext()
             )
+
+            with autocast_ctx:
+                # Use directory path - SAM-2 loads frames on demand
+                inference_state = self.video_predictor.init_state(
+                    video_path=str(frames_dir),
+                    offload_video_to_cpu=self.config.get("offload_video_to_cpu", False),
+                    offload_state_to_cpu=self.config.get("offload_state_to_cpu", False),
+                )
 
             init_time = time.perf_counter() - start_time
             self.metrics["video_state_init_time_seconds"] = init_time
@@ -1122,45 +1132,54 @@ class ObjectSegmentationStage:
 
         object_info = {}
 
-        for obj_id, detection in enumerate(detections):
-            frame_idx = detection["frame_idx"]
-            mask = detection["mask"]
-            img_height, img_width = mask.shape
+        # Use autocast for BFloat16 compatibility with SAM-2 video predictor
+        # See: https://github.com/facebookresearch/sam2/issues/577
+        autocast_ctx = (
+            torch.autocast("cuda", dtype=torch.bfloat16)
+            if self.device == "cuda"
+            else nullcontext()
+        )
 
-            # Convert bbox from XYWH to XYXY format
-            x, y, w, h = detection["bbox"]
-            bbox_xyxy = [x, y, x + w, y + h]
+        with autocast_ctx:
+            for obj_id, detection in enumerate(detections):
+                frame_idx = detection["frame_idx"]
+                mask = detection["mask"]
+                img_height, img_width = mask.shape
 
-            # Normalize to 0-1 range for SAM-2
-            bbox_normalized = self._normalize_bbox(bbox_xyxy, img_height, img_width)
+                # Convert bbox from XYWH to XYXY format
+                x, y, w, h = detection["bbox"]
+                bbox_xyxy = [x, y, x + w, y + h]
 
-            try:
-                # Add bounding box prompt to video predictor
-                _, out_obj_ids, out_masks = self.video_predictor.add_new_points_or_box(
-                    inference_state=inference_state,
-                    frame_idx=frame_idx,
-                    obj_id=obj_id,
-                    box=np.array(bbox_normalized),
-                    normalize_coords=True,
-                )
+                # Normalize to 0-1 range for SAM-2
+                bbox_normalized = self._normalize_bbox(bbox_xyxy, img_height, img_width)
 
-                object_info[obj_id] = {
-                    "source_frame": frame_idx,
-                    "source_confidence": detection["confidence"],
-                    "source_bbox": detection["bbox"],
-                }
+                try:
+                    # Add bounding box prompt to video predictor
+                    _, out_obj_ids, out_masks = self.video_predictor.add_new_points_or_box(
+                        inference_state=inference_state,
+                        frame_idx=frame_idx,
+                        obj_id=obj_id,
+                        box=np.array(bbox_normalized),
+                        normalize_coords=True,
+                    )
 
-                logger.debug(
-                    f"Added prompt for object {obj_id} at frame {frame_idx} "
-                    f"with bbox {bbox_normalized}"
-                )
+                    object_info[obj_id] = {
+                        "source_frame": frame_idx,
+                        "source_confidence": detection["confidence"],
+                        "source_bbox": detection["bbox"],
+                    }
 
-            except Exception as e:
-                logger.error(
-                    f"[SEG-ERR-015] Failed to add prompt for object {obj_id} "
-                    f"at frame {frame_idx}: {e}"
-                )
-                raise
+                    logger.debug(
+                        f"Added prompt for object {obj_id} at frame {frame_idx} "
+                        f"with bbox {bbox_normalized}"
+                    )
+
+                except Exception as e:
+                    logger.error(
+                        f"[SEG-ERR-015] Failed to add prompt for object {obj_id} "
+                        f"at frame {frame_idx}: {e}"
+                    )
+                    raise
 
         logger.info(f"Successfully added {len(object_info)} object prompts")
         return object_info
@@ -1192,45 +1211,54 @@ class ObjectSegmentationStage:
         all_masks = {}
         frames_processed = 0
 
+        # Use autocast for BFloat16 compatibility with SAM-2 video predictor
+        # See: https://github.com/facebookresearch/sam2/issues/577
+        autocast_ctx = (
+            torch.autocast("cuda", dtype=torch.bfloat16)
+            if self.device == "cuda"
+            else nullcontext()
+        )
+
         try:
-            for frame_idx, obj_ids, mask_logits in self.video_predictor.propagate_in_video(
-                inference_state=inference_state,
-            ):
-                frames_processed += 1
+            with autocast_ctx:
+                for frame_idx, obj_ids, mask_logits in self.video_predictor.propagate_in_video(
+                    inference_state=inference_state,
+                ):
+                    frames_processed += 1
 
-                if progress_callback:
-                    progress = frames_processed / num_frames
-                    progress_callback(
-                        progress, f"Tracking frame {frames_processed}/{num_frames}"
-                    )
+                    if progress_callback:
+                        progress = frames_processed / num_frames
+                        progress_callback(
+                            progress, f"Tracking frame {frames_processed}/{num_frames}"
+                        )
 
-                frame_data = []
+                    frame_data = []
 
-                # Process each object's mask for this frame
-                for i, obj_id in enumerate(obj_ids):
-                    # Convert logits to binary mask
-                    # mask_logits shape: (num_objects, H, W) or (1, H, W) per object
-                    mask = (mask_logits[i] > 0.0).cpu().numpy()
+                    # Process each object's mask for this frame
+                    for i, obj_id in enumerate(obj_ids):
+                        # Convert logits to binary mask
+                        # mask_logits shape: (num_objects, H, W) or (1, H, W) per object
+                        mask = (mask_logits[i] > 0.0).cpu().numpy()
 
-                    # Skip empty masks (object not visible in this frame)
-                    if not mask.any():
-                        continue
+                        # Skip empty masks (object not visible in this frame)
+                        if not mask.any():
+                            continue
 
-                    # Compute per-frame metadata for Stage 4
-                    bbox = self._mask_to_bbox(mask)
-                    centroid = self._mask_to_centroid(mask)
-                    area = int(mask.sum())
+                        # Compute per-frame metadata for Stage 4
+                        bbox = self._mask_to_bbox(mask)
+                        centroid = self._mask_to_centroid(mask)
+                        area = int(mask.sum())
 
-                    frame_data.append({
-                        "object_id": int(obj_id),
-                        "mask": mask,
-                        "bbox": bbox,
-                        "centroid": centroid,
-                        "area": area,
-                    })
+                        frame_data.append({
+                            "object_id": int(obj_id),
+                            "mask": mask,
+                            "bbox": bbox,
+                            "centroid": centroid,
+                            "area": area,
+                        })
 
-                if frame_data:
-                    all_masks[frame_idx] = frame_data
+                    if frame_data:
+                        all_masks[frame_idx] = frame_data
 
             propagate_time = time.perf_counter() - start_time
             self.metrics["propagation_time_seconds"] = propagate_time


### PR DESCRIPTION
## Summary

Fixes a runtime error in Phase 3 (Object Tracking) where SAM-2's video predictor crashes with a dtype mismatch when running on GPU.

**Error:** `RuntimeError: mat1 and mat2 must have the same dtype, but got BFloat16 and Float`

## Root Cause

SAM-2's video predictor model loads with BFloat16 weights on modern GPUs, but internal operations create Float32 intermediate tensors. When these interact during `propagate_in_video()`, PyTorch raises a dtype mismatch error.

Phase 2 (keyframe segmentation) already uses `torch.cuda.amp.autocast()`, but Phase 3 was missing this context.

## Fix

Added `torch.autocast("cuda", dtype=torch.bfloat16)` wrapper to all three Phase 3 video predictor methods:

1. `_init_video_state()` - wraps `predictor.init_state()`
2. `_add_object_prompts()` - wraps `predictor.add_new_points_or_box()`
3. `_propagate_masks()` - wraps `predictor.propagate_in_video()`

This follows the [official SAM-2 recommendation](https://github.com/facebookresearch/sam2/issues/577).

## Files Changed

| File | Changes |
|------|---------|
| `backend/stages/object_segmentation.py` | Added `nullcontext` import, wrapped 3 methods in autocast |
| `docs/STATUS.md` | Documented BFloat16 autocast fix |
| `docs/ROADMAP.md` | Added autocast checkbox to Phase 3 |

## Testing

Re-run integration test in Google Colab:
1. Pull latest changes: `git pull origin feat/object-segmentation`
2. Run Cell 6 (Full Pipeline Integration Test)
3. Verify all 15 frames are tracked without dtype errors
4. Check `object_metadata.json` is generated with quality metrics

## Breaking Changes

None. This is a bugfix that enables Phase 3 to run on GPU as intended.

## References

- [SAM-2 Issue #577: BFloat16/Float dtype mismatch](https://github.com/facebookresearch/sam2/issues/577)
- [SAM-2 Issue #308: Reverse propagation dtype error](https://github.com/facebookresearch/sam2/issues/308)