### PR TITLE
feat: add instant 4d adapter (phase 0, stage 2)

### DIFF
--- a/backend/adapters/__init__.py
+++ b/backend/adapters/__init__.py
@@ -13,6 +13,9 @@ from .video_to_3dgs import VideoTo3DGSAdapter
 # Legacy adapter (kept for MoGe-V2 depth estimation in hole-filling)
 from .versecrafter import VerseCrafterAdapter
 
+# Instant4D adapter for 4D Gaussian Splatting (used internally by GaussianTrainingStage)
+from .instant4d import Instant4DAdapter, Instant4DOptions, Instant4DResult
+
 # Registry of available adapters
 ADAPTERS = {
     "video_to_3dgs": VideoTo3DGSAdapter,
@@ -68,6 +71,9 @@ __all__ = [
     "CameraInfo",
     "VideoTo3DGSAdapter",
     "VerseCrafterAdapter",
+    "Instant4DAdapter",
+    "Instant4DOptions",
+    "Instant4DResult",
     "get_adapter",
     "list_adapters",
     "ADAPTERS",

--- a/backend/adapters/instant4d.py
+++ b/backend/adapters/instant4d.py
@@ -1,0 +1,1280 @@
+"""Instant4D adapter for 4D Gaussian Splatting reconstruction.
+
+This adapter wraps the Instant4D pipeline to enable true 4D reconstruction
+from video input, replacing the static 3DGS approach with temporal Gaussians.
+
+Key capabilities:
+- Preprocessing: Convert Stage 1/2 outputs to Instant4D format
+- Grid Pruning: Voxel-based 92% Gaussian reduction
+- 4D Training: Optimize 4D Gaussians (~2-5 min)
+- Per-frame Export: Extract PLYs at arbitrary timestamps
+
+Requirements:
+    - CUDA 12.1+
+    - PyTorch 2.3+
+    - Instant4D CUDA kernels compiled (run scripts/setup_instant4d.sh)
+    - ~24GB VRAM for training
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Callable, List, Tuple, Dict, Any
+import json
+import logging
+import sys
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass
+class Instant4DOptions:
+    """Options for Instant4D 4D Gaussian training."""
+
+    # Training parameters
+    iterations: int = 5000
+    """Number of optimization iterations."""
+
+    batch_size: int = 1
+    """Training batch size."""
+
+    gaussian_dim: int = 4
+    """Gaussian dimension: 3 for static, 4 for temporal."""
+
+    time_duration: Tuple[float, float] = (0.0, 3.0)
+    """Temporal range for 4D Gaussians."""
+
+    rot_4d: bool = True
+    """Enable 4D rotation representation."""
+
+    num_pts: int = 100_000
+    """Initial number of points."""
+
+    # Preprocessing
+    use_megasam: bool = False
+    """Use Mega-SAM preprocessing (requires additional deps)."""
+
+    motion_threshold: float = 0.5
+    """Threshold for static/dynamic separation."""
+
+    # Grid pruning
+    enable_pruning: bool = True
+    """Enable voxel-based grid pruning."""
+
+    static_voxel_scale: float = 2.0
+    """Voxel size scale for static regions."""
+
+    dynamic_voxel_scale: float = 0.5
+    """Voxel size scale for dynamic regions."""
+
+    # Export
+    export_fps: float = 30.0
+    """Frames per second for PLY export."""
+
+    opacity_threshold: float = 0.01
+    """Minimum opacity for including Gaussians in export."""
+
+
+@dataclass
+class Instant4DResult:
+    """Result of Instant4D 4D Gaussian training."""
+
+    model_path: str
+    """Path to trained 4D Gaussian model checkpoint (.pth)."""
+
+    ply_paths: List[str] = field(default_factory=list)
+    """Paths to per-frame PLY files extracted from 4D model."""
+
+    num_gaussians: int = 0
+    """Total number of 4D Gaussians in trained model."""
+
+    num_frames: int = 0
+    """Number of frames/timestamps extracted."""
+
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    """Training metrics (PSNR, SSIM, timing, etc.)."""
+
+    config_path: Optional[str] = None
+    """Path to training configuration used."""
+
+    temporal_metadata: Dict[str, Any] = field(default_factory=dict)
+    """Temporal metadata (fps, duration, timestamps)."""
+
+
+# =============================================================================
+# Instant4D Adapter
+# =============================================================================
+
+
+class Instant4DAdapter:
+    """
+    Adapter for Instant4D 4D Gaussian Splatting pipeline.
+
+    This adapter enables:
+    1. Preprocessing - Convert Stage 1 output to Instant4D format
+    2. Grid Pruning - Voxel-based 92% Gaussian reduction
+    3. 4D Training - Optimize 4D Gaussians (~2-5 min)
+    4. Per-frame Export - Extract PLYs at arbitrary timestamps
+
+    Integration with Stage 2:
+    - Uses SAM-2 masks to populate prob_motion field
+    - Enables dynamic/static region separation
+
+    Example:
+        >>> adapter = Instant4DAdapter()
+        >>> result = adapter.run_full_pipeline(
+        ...     video_result=stage1_output,
+        ...     segmentation_result=stage2_output,  # Optional
+        ...     output_dir="/path/to/output",
+        ...     options=Instant4DOptions(iterations=5000),
+        ... )
+        >>> print(f"Exported {result.num_frames} PLY files")
+    """
+
+    # Path to Instant4D submodule (relative to this file)
+    INSTANT4D_PATH = Path(__file__).parent.parent.parent / "instant4d"
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize Instant4D adapter.
+
+        Args:
+            config: Optional configuration dictionary with keys:
+                - device: CUDA device (default: "cuda:0")
+                - instant4d_path: Override Instant4D submodule path
+        """
+        self.config = config or {}
+        self.device = self.config.get("device", "cuda:0")
+
+        # Allow overriding Instant4D path
+        if "instant4d_path" in self.config:
+            self.INSTANT4D_PATH = Path(self.config["instant4d_path"])
+
+        # Lazy-loaded models
+        self._gaussian_model = None
+        self._scene = None
+        self._path_added = False
+
+        # Validate installation
+        self._validate_installation()
+
+    def _validate_installation(self) -> None:
+        """
+        Validate Instant4D submodule is properly installed.
+
+        Raises:
+            ImportError: If Instant4D is not found or incomplete
+        """
+        if not self.INSTANT4D_PATH.exists():
+            raise ImportError(
+                f"Instant4D submodule not found at {self.INSTANT4D_PATH}. "
+                "Run: git submodule update --init --recursive"
+            )
+
+        # Check for essential files
+        required_files = [
+            "scene/gaussian_model.py",
+            "gaussian_renderer/__init__.py",
+            "scene/__init__.py",
+        ]
+
+        missing = []
+        for f in required_files:
+            if not (self.INSTANT4D_PATH / f).exists():
+                missing.append(f)
+
+        if missing:
+            raise ImportError(
+                f"Instant4D installation incomplete. Missing: {missing}. "
+                "Run: git submodule update --init --recursive"
+            )
+
+        logger.info(f"Instant4D found at {self.INSTANT4D_PATH}")
+
+    def _add_instant4d_to_path(self) -> None:
+        """Add Instant4D to Python path for imports."""
+        if self._path_added:
+            return
+
+        instant4d_str = str(self.INSTANT4D_PATH)
+        if instant4d_str not in sys.path:
+            sys.path.insert(0, instant4d_str)
+            self._path_added = True
+            logger.debug(f"Added {instant4d_str} to Python path")
+
+    def _validate_cuda_kernels(self) -> None:
+        """
+        Validate CUDA kernels are compiled and importable.
+
+        Raises:
+            ImportError: If CUDA kernels are not available
+        """
+        self._add_instant4d_to_path()
+
+        try:
+            from diff_gaussian_rasterization import GaussianRasterizer
+
+            assert GaussianRasterizer is not None
+        except ImportError as e:
+            raise ImportError(
+                f"CUDA kernel 'diff-gaussian-rasterization' not available: {e}. "
+                "Run: bash scripts/setup_instant4d.sh"
+            ) from e
+
+        try:
+            from simple_knn import distCUDA2
+
+            assert distCUDA2 is not None
+        except ImportError as e:
+            raise ImportError(
+                f"CUDA kernel 'simple-knn' not available: {e}. "
+                "Run: bash scripts/setup_instant4d.sh"
+            ) from e
+
+        logger.info("CUDA kernels validated successfully")
+
+    # =========================================================================
+    # Main Pipeline Methods
+    # =========================================================================
+
+    def preprocess(
+        self,
+        video_result: "VideoProcessingResult",
+        segmentation_result: Optional["ObjectSegmentationResult"],
+        output_dir: str,
+        options: Optional[Instant4DOptions] = None,
+        progress_callback: Optional[Callable[[float, str], None]] = None,
+    ) -> Path:
+        """
+        Preprocess video data for Instant4D training.
+
+        Converts Stage 1/2 outputs to Instant4D's filtered_cvd.npz format:
+        - xyz: 3D point positions
+        - rgb: Point colors
+        - prob_motion: Motion probability (from Stage 2 masks)
+        - time_stamp: Temporal coordinate
+        - scale_time: Temporal scale
+        - intrinsic: Camera intrinsics
+        - cam_c2w: Camera-to-world transforms
+
+        Args:
+            video_result: Output from Stage 1 (frames + poses)
+            segmentation_result: Output from Stage 2 (masks for motion), optional
+            output_dir: Directory to store preprocessed data
+            options: Preprocessing options
+            progress_callback: Progress updates (pct: float, msg: str)
+
+        Returns:
+            Path to preprocessed data directory (contains filtered_cvd.npz)
+        """
+        options = options or Instant4DOptions()
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        def report(pct: float, msg: str) -> None:
+            if progress_callback:
+                progress_callback(pct, msg)
+            logger.info(f"[{pct*100:.0f}%] {msg}")
+
+        report(0.0, "Starting preprocessing")
+
+        # Step 1: Load camera transforms from Stage 1
+        report(0.05, "Loading camera transforms")
+        transforms = self._load_transforms(video_result.transforms_path)
+        frames = transforms["frames"]
+        num_frames = len(frames)
+
+        # Step 2: Extract intrinsics
+        report(0.1, "Extracting camera intrinsics")
+        intrinsic = self._extract_intrinsics(transforms)
+
+        # Step 3: Convert poses from Nerfstudio to Instant4D format
+        report(0.15, "Converting camera poses")
+        cam_c2w = self._convert_poses_nerfstudio_to_instant4d(frames)
+
+        # Step 4: Load or generate point cloud
+        report(0.2, "Loading point cloud")
+        if video_result.sparse_points_path and Path(video_result.sparse_points_path).exists():
+            xyz, rgb = self._load_sparse_points(video_result.sparse_points_path)
+            report(0.3, f"Loaded {xyz.shape[0]} sparse points")
+        else:
+            xyz, rgb = self._generate_initial_points(
+                cam_c2w, intrinsic, num_frames, options.num_pts
+            )
+            report(0.3, f"Generated {xyz.shape[0]} initial points")
+
+        # Step 5: Compute motion probabilities from Stage 2 masks
+        report(0.4, "Computing motion probabilities")
+        if segmentation_result and segmentation_result.objects:
+            prob_motion = self._compute_motion_from_masks(
+                segmentation_result, xyz, frames, cam_c2w, intrinsic
+            )
+            num_dynamic = np.sum(prob_motion > options.motion_threshold)
+            report(0.5, f"Found {num_dynamic} dynamic points")
+        else:
+            # No segmentation - assume all static
+            prob_motion = np.zeros(xyz.shape[0], dtype=np.float32)
+            logger.warning(
+                "No segmentation data provided. Assuming all points are static."
+            )
+            report(0.5, "No segmentation data - assuming all static")
+
+        # Step 6: Assign timestamps to points
+        report(0.55, "Assigning temporal coordinates")
+        time_stamp, scale_time = self._assign_timestamps(
+            xyz, prob_motion, num_frames, options
+        )
+
+        # Step 7: Apply voxel grid pruning
+        if options.enable_pruning:
+            report(0.6, "Applying voxel grid pruning")
+            original_count = xyz.shape[0]
+            xyz, rgb, prob_motion, time_stamp, scale_time = self._voxel_filter(
+                xyz, rgb, prob_motion, time_stamp, scale_time, intrinsic, cam_c2w, options
+            )
+            reduction = (1 - xyz.shape[0] / original_count) * 100
+            report(0.75, f"Pruned to {xyz.shape[0]} points ({reduction:.0f}% reduction)")
+        else:
+            report(0.75, "Skipping voxel pruning")
+
+        # Step 8: Save filtered_cvd.npz
+        report(0.8, "Saving preprocessed data")
+        np.savez(
+            output_path / "filtered_cvd.npz",
+            xyz=xyz.astype(np.float32),
+            rgb=rgb.astype(np.float32),
+            prob_motion=prob_motion.astype(np.float32),
+            time_stamp=time_stamp.astype(np.float32),
+            scale_time=scale_time.astype(np.float32),
+            intrinsic=intrinsic.astype(np.float32),
+            cam_c2w=cam_c2w.astype(np.float32),
+        )
+
+        # Step 9: Create transforms_train.json and transforms_test.json
+        report(0.9, "Creating Instant4D transforms")
+        self._create_instant4d_transforms(
+            transforms, video_result.frames_dir, output_path, num_frames
+        )
+
+        report(1.0, "Preprocessing complete")
+        return output_path
+
+    def train(
+        self,
+        preprocessed_dir: str,
+        output_dir: str,
+        options: Optional[Instant4DOptions] = None,
+        progress_callback: Optional[Callable[[float, str], None]] = None,
+    ) -> Instant4DResult:
+        """
+        Train 4D Gaussian model.
+
+        Runs Instant4D's optimization pipeline:
+        1. Load preprocessed data (filtered_cvd.npz + transforms)
+        2. Initialize 4D Gaussians from point cloud
+        3. Run optimization loop with densification
+        4. Save checkpoint and metrics
+
+        Training is ~2-5 minutes on typical video.
+
+        Args:
+            preprocessed_dir: Path to preprocessed data
+            output_dir: Directory for training outputs
+            options: Training hyperparameters
+            progress_callback: Progress updates (pct: float, msg: str)
+
+        Returns:
+            Instant4DResult with model path and metrics
+        """
+        options = options or Instant4DOptions()
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        def report(pct: float, msg: str) -> None:
+            if progress_callback:
+                progress_callback(pct, msg)
+            logger.info(f"[{pct*100:.0f}%] {msg}")
+
+        report(0.0, "Initializing training")
+
+        # Validate CUDA kernels before training
+        self._validate_cuda_kernels()
+
+        # Add Instant4D to path
+        self._add_instant4d_to_path()
+
+        # Import Instant4D modules
+        report(0.02, "Loading Instant4D modules")
+        from scene.gaussian_model import GaussianModel
+        from scene import Scene
+
+        # Build configuration
+        report(0.05, "Building training configuration")
+        model_params, opt_params, pipe_params = self._build_training_config(
+            preprocessed_dir, output_path, options
+        )
+
+        # Initialize model
+        report(0.08, "Initializing 4D Gaussian model")
+        gaussians = GaussianModel(
+            sh_degree=0,
+            gaussian_dim=options.gaussian_dim,
+            time_duration=list(options.time_duration),
+            rot_4d=options.rot_4d,
+            force_sh_3d=False,
+        )
+
+        # Load scene
+        report(0.1, "Loading scene data")
+        scene = Scene(model_params, gaussians, time_duration=list(options.time_duration))
+
+        # Setup optimizer
+        report(0.12, "Setting up optimizer")
+        gaussians.training_setup(opt_params)
+
+        # Training loop
+        import torch
+        from gaussian_renderer import render
+
+        bg_color = torch.tensor([0, 0, 0], dtype=torch.float32, device="cuda")
+        training_cameras = scene.getTrainCameras()
+
+        if len(training_cameras) == 0:
+            raise RuntimeError("No training cameras found. Check preprocessed data.")
+
+        total_iterations = options.iterations
+        metrics_history = {"psnr": [], "loss": []}
+
+        report(0.15, f"Starting training ({total_iterations} iterations)")
+
+        for iteration in range(1, total_iterations + 1):
+            # Sample training view
+            camera_idx = iteration % len(training_cameras)
+            viewpoint = training_cameras[camera_idx]
+
+            # Render
+            render_pkg = render(viewpoint, gaussians, pipe_params, bg_color)
+            image = render_pkg["render"]
+
+            # Get ground truth
+            gt_image = viewpoint.original_image.cuda()
+
+            # Compute loss
+            loss = self._compute_loss(image, gt_image)
+            loss.backward()
+
+            # Optimizer step
+            gaussians.optimizer.step()
+            gaussians.optimizer.zero_grad(set_to_none=True)
+
+            # Track metrics
+            with torch.no_grad():
+                psnr = self._compute_psnr(image, gt_image)
+                metrics_history["psnr"].append(psnr)
+                metrics_history["loss"].append(loss.item())
+
+            # Progress update every 100 iterations
+            if iteration % 100 == 0 or iteration == 1:
+                pct = 0.15 + 0.75 * (iteration / total_iterations)
+                report(pct, f"Iteration {iteration}/{total_iterations}, PSNR: {psnr:.2f}")
+
+            # Densification and pruning
+            if iteration < opt_params.densify_until_iter:
+                gaussians.max_radii2D[render_pkg["visibility_filter"]] = torch.max(
+                    gaussians.max_radii2D[render_pkg["visibility_filter"]],
+                    render_pkg["radii"][render_pkg["visibility_filter"]],
+                )
+                gaussians.add_densification_stats(
+                    render_pkg["viewspace_points"], render_pkg["visibility_filter"]
+                )
+
+                if (
+                    iteration > opt_params.densify_from_iter
+                    and iteration % opt_params.densification_interval == 0
+                ):
+                    size_threshold = (
+                        20 if iteration > opt_params.opacity_reset_interval else None
+                    )
+                    gaussians.densify_and_prune(
+                        opt_params.densify_grad_threshold,
+                        opt_params.thresh_opa_prune,
+                        scene.cameras_extent,
+                        size_threshold,
+                    )
+
+        # Save checkpoint
+        report(0.92, "Saving model checkpoint")
+        checkpoint_path = output_path / "model.pth"
+        torch.save(gaussians.capture(), checkpoint_path)
+
+        # Save config
+        config_path = output_path / "config.yaml"
+        self._save_config(config_path, options)
+
+        # Compute final metrics
+        report(0.95, "Computing final metrics")
+        final_metrics = self._compute_final_metrics(
+            scene, gaussians, pipe_params, bg_color
+        )
+        final_metrics["training_history"] = metrics_history
+
+        # Store for later use
+        self._gaussian_model = gaussians
+        self._scene = scene
+        self._pipe_params = pipe_params
+
+        report(1.0, "Training complete")
+
+        return Instant4DResult(
+            model_path=str(checkpoint_path),
+            num_gaussians=gaussians.get_xyz.shape[0],
+            metrics=final_metrics,
+            config_path=str(config_path),
+        )
+
+    def extract_per_frame_ply(
+        self,
+        model_path: str,
+        output_dir: str,
+        timestamps: Optional[List[float]] = None,
+        progress_callback: Optional[Callable[[float, str], None]] = None,
+    ) -> List[str]:
+        """
+        Extract per-frame PLY files from trained 4D model.
+
+        Queries the 4D Gaussian model at each timestamp to get:
+        - Current 3D position (mean + temporal offset)
+        - Current covariance (marginal at timestamp)
+        - Current opacity (weighted by temporal Gaussian)
+        - Color (from spherical harmonics)
+
+        Args:
+            model_path: Path to trained model checkpoint
+            output_dir: Directory for PLY outputs
+            timestamps: List of timestamps to export (default: derived from training)
+            progress_callback: Progress updates (pct: float, msg: str)
+
+        Returns:
+            List of paths to exported PLY files
+        """
+        import torch
+
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        def report(pct: float, msg: str) -> None:
+            if progress_callback:
+                progress_callback(pct, msg)
+            logger.info(f"[{pct*100:.0f}%] {msg}")
+
+        report(0.0, "Starting per-frame PLY export")
+
+        # Load model if not already in memory
+        if self._gaussian_model is None:
+            report(0.05, "Loading model checkpoint")
+            self._gaussian_model = self._load_model(model_path)
+
+        gaussians = self._gaussian_model
+
+        # Determine timestamps to export
+        if timestamps is None:
+            t_min, t_max = gaussians.time_duration
+            # Default: 30 frames
+            num_frames = 30
+            timestamps = np.linspace(t_min, t_max, num_frames).tolist()
+
+        ply_paths = []
+        num_timestamps = len(timestamps)
+
+        report(0.1, f"Exporting {num_timestamps} frames")
+
+        for i, timestamp in enumerate(timestamps):
+            with torch.no_grad():
+                # Get temporal marginal weight
+                marginal_t = gaussians.get_marginal_t(timestamp)
+
+                # Get current position at this timestamp
+                if hasattr(gaussians, "rot_4d") and gaussians.rot_4d:
+                    try:
+                        _, delta_mean = gaussians.get_current_covariance_and_mean_offset(
+                            scaling_modifier=1.0, timestamp=timestamp
+                        )
+                        xyz = (gaussians.get_xyz + delta_mean).cpu().numpy()
+                    except Exception:
+                        # Fallback if method not available
+                        xyz = gaussians.get_xyz.cpu().numpy()
+                else:
+                    xyz = gaussians.get_xyz.cpu().numpy()
+
+                # Filter by temporal weight
+                opacity = gaussians.get_opacity.cpu().numpy().squeeze()
+                marginal_np = marginal_t.cpu().numpy().squeeze()
+                effective_opacity = opacity * marginal_np
+                active_mask = effective_opacity > 0.01
+
+                xyz_active = xyz[active_mask]
+
+                # Get colors from spherical harmonics (DC term)
+                shs = gaussians._features_dc.cpu().numpy()
+                # SH DC to RGB: color = SH * 0.28209479177 + 0.5
+                rgb = shs[active_mask, 0, :] * 0.28209479177 + 0.5
+                rgb = np.clip(rgb * 255, 0, 255).astype(np.uint8)
+
+            # Write PLY
+            ply_path = output_path / f"frame_{i:04d}.ply"
+            self._write_ply(ply_path, xyz_active, rgb)
+            ply_paths.append(str(ply_path))
+
+            # Progress update
+            pct = 0.1 + 0.85 * ((i + 1) / num_timestamps)
+            if (i + 1) % 5 == 0 or i == 0 or i == num_timestamps - 1:
+                report(pct, f"Exported frame {i+1}/{num_timestamps} ({xyz_active.shape[0]} points)")
+
+        report(1.0, f"Export complete: {len(ply_paths)} PLY files")
+
+        return ply_paths
+
+    def run_full_pipeline(
+        self,
+        video_result: "VideoProcessingResult",
+        segmentation_result: Optional["ObjectSegmentationResult"],
+        output_dir: str,
+        options: Optional[Instant4DOptions] = None,
+        progress_callback: Optional[Callable[[float, str], None]] = None,
+    ) -> Instant4DResult:
+        """
+        Run complete Instant4D pipeline: preprocess -> train -> export.
+
+        This is the main entry point for Stage 3 integration.
+
+        Args:
+            video_result: Output from Stage 1 (frames + poses)
+            segmentation_result: Output from Stage 2 (masks), optional
+            output_dir: Directory for all outputs
+            options: Pipeline options
+            progress_callback: Progress updates (pct: float, msg: str)
+
+        Returns:
+            Instant4DResult with model path, PLY paths, and metrics
+        """
+        options = options or Instant4DOptions()
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        def report(pct: float, msg: str) -> None:
+            if progress_callback:
+                progress_callback(pct, msg)
+
+        # Phase 1: Preprocessing (0-20%)
+        report(0.0, "Phase 1: Preprocessing")
+        preprocessed_dir = self.preprocess(
+            video_result,
+            segmentation_result,
+            str(output_path / "preprocessed"),
+            options,
+            lambda p, m: report(p * 0.2, f"[Preprocess] {m}"),
+        )
+
+        # Phase 2: Training (20-80%)
+        report(0.2, "Phase 2: Training 4D Gaussians")
+        result = self.train(
+            str(preprocessed_dir),
+            str(output_path / "trained"),
+            options,
+            lambda p, m: report(0.2 + p * 0.6, f"[Train] {m}"),
+        )
+
+        # Phase 3: Export (80-100%)
+        report(0.8, "Phase 3: Exporting per-frame PLYs")
+        ply_paths = self.extract_per_frame_ply(
+            result.model_path,
+            str(output_path / "plys"),
+            progress_callback=lambda p, m: report(0.8 + p * 0.2, f"[Export] {m}"),
+        )
+
+        # Update result
+        result.ply_paths = ply_paths
+        result.num_frames = len(ply_paths)
+        result.temporal_metadata = {
+            "fps": options.export_fps,
+            "duration_seconds": len(ply_paths) / options.export_fps,
+            "num_frames": len(ply_paths),
+            "timestamps": list(
+                np.linspace(
+                    options.time_duration[0], options.time_duration[1], len(ply_paths)
+                )
+            ),
+        }
+
+        report(1.0, "Instant4D pipeline complete")
+        return result
+
+    def cleanup(self) -> None:
+        """Release GPU memory and resources."""
+        if self._gaussian_model is not None:
+            del self._gaussian_model
+            self._gaussian_model = None
+
+        if self._scene is not None:
+            del self._scene
+            self._scene = None
+
+        if hasattr(self, "_pipe_params"):
+            del self._pipe_params
+
+        # Clear CUDA cache
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except ImportError:
+            pass
+
+        logger.info("Instant4D adapter resources cleaned up")
+
+    # =========================================================================
+    # Internal Helper Methods
+    # =========================================================================
+
+    def _load_transforms(self, transforms_path: str) -> Dict[str, Any]:
+        """Load and validate transforms.json from Stage 1."""
+        with open(transforms_path) as f:
+            transforms = json.load(f)
+
+        # Validate required fields
+        if "frames" not in transforms:
+            raise ValueError(f"transforms.json missing 'frames' key: {transforms_path}")
+
+        return transforms
+
+    def _extract_intrinsics(self, transforms: Dict[str, Any]) -> np.ndarray:
+        """Extract camera intrinsics matrix from transforms."""
+        intrinsic = np.eye(3, dtype=np.float32)
+
+        # Handle different intrinsic formats
+        if "fl_x" in transforms:
+            intrinsic[0, 0] = transforms["fl_x"]
+            intrinsic[1, 1] = transforms.get("fl_y", transforms["fl_x"])
+            intrinsic[0, 2] = transforms.get("cx", transforms.get("w", 640) / 2)
+            intrinsic[1, 2] = transforms.get("cy", transforms.get("h", 480) / 2)
+        elif "camera_angle_x" in transforms:
+            # Nerfstudio format with angle
+            w = transforms.get("w", 640)
+            h = transforms.get("h", 480)
+            fov_x = transforms["camera_angle_x"]
+            fl_x = w / (2 * np.tan(fov_x / 2))
+            intrinsic[0, 0] = fl_x
+            intrinsic[1, 1] = fl_x
+            intrinsic[0, 2] = w / 2
+            intrinsic[1, 2] = h / 2
+        else:
+            # Default fallback
+            logger.warning("No intrinsics found in transforms, using defaults")
+            intrinsic[0, 0] = 500
+            intrinsic[1, 1] = 500
+            intrinsic[0, 2] = 320
+            intrinsic[1, 2] = 240
+
+        return intrinsic
+
+    def _convert_poses_nerfstudio_to_instant4d(
+        self, frames: List[Dict[str, Any]]
+    ) -> np.ndarray:
+        """
+        Convert camera poses from Nerfstudio (OpenGL) to Instant4D (COLMAP-like) convention.
+
+        OpenGL: Y-up, Z-back (looking at -Z)
+        COLMAP/Instant4D: Y-down, Z-forward
+
+        Args:
+            frames: List of frame dicts with "transform_matrix"
+
+        Returns:
+            Camera-to-world matrices (N, 4, 4)
+        """
+        cam_c2w = []
+
+        for frame in frames:
+            c2w = np.array(frame["transform_matrix"], dtype=np.float32)
+
+            # Ensure 4x4
+            if c2w.shape == (3, 4):
+                c2w = np.vstack([c2w, [0, 0, 0, 1]])
+
+            # Convert from OpenGL to COLMAP convention
+            # Flip Y and Z axes
+            c2w[:3, 1:3] *= -1
+
+            cam_c2w.append(c2w)
+
+        return np.stack(cam_c2w)
+
+    def _load_sparse_points(self, ply_path: str) -> Tuple[np.ndarray, np.ndarray]:
+        """Load sparse point cloud from PLY file."""
+        try:
+            from plyfile import PlyData
+        except ImportError:
+            raise ImportError("plyfile required. Install with: pip install plyfile")
+
+        plydata = PlyData.read(ply_path)
+        vertex = plydata["vertex"]
+
+        xyz = np.vstack([vertex["x"], vertex["y"], vertex["z"]]).T
+
+        # Try to load colors
+        if "red" in vertex:
+            rgb = np.vstack([vertex["red"], vertex["green"], vertex["blue"]]).T
+            rgb = rgb.astype(np.float32) / 255.0
+        else:
+            rgb = np.ones((xyz.shape[0], 3), dtype=np.float32) * 0.5
+
+        return xyz.astype(np.float32), rgb.astype(np.float32)
+
+    def _generate_initial_points(
+        self,
+        cam_c2w: np.ndarray,
+        intrinsic: np.ndarray,
+        num_frames: int,
+        num_pts: int,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Generate initial point cloud from camera frustums."""
+        # Simple approach: sample points in a bounding box around cameras
+        camera_centers = cam_c2w[:, :3, 3]
+        center = camera_centers.mean(axis=0)
+        extent = (camera_centers.max(axis=0) - camera_centers.min(axis=0)).max() * 2
+
+        # Random points in bounding box
+        xyz = (np.random.rand(num_pts, 3) - 0.5) * extent + center
+        rgb = np.random.rand(num_pts, 3).astype(np.float32)
+
+        return xyz.astype(np.float32), rgb
+
+    def _compute_motion_from_masks(
+        self,
+        segmentation_result: "ObjectSegmentationResult",
+        xyz: np.ndarray,
+        frames: List[Dict[str, Any]],
+        cam_c2w: np.ndarray,
+        intrinsic: np.ndarray,
+    ) -> np.ndarray:
+        """
+        Compute per-point motion probability from Stage 2 masks.
+
+        Strategy:
+        1. For each 3D point, project to each frame
+        2. Check if point falls inside any object mask
+        3. Aggregate across frames to get motion probability
+        """
+        import cv2
+
+        num_points = xyz.shape[0]
+        motion_counts = np.zeros(num_points, dtype=np.float32)
+        visible_counts = np.zeros(num_points, dtype=np.float32)
+
+        # Build mask lookup by frame index
+        frame_masks: Dict[int, List[np.ndarray]] = {}
+        for obj in segmentation_result.objects:
+            for frame_idx, mask_path in zip(obj.frame_indices, obj.mask_paths):
+                if frame_idx not in frame_masks:
+                    frame_masks[frame_idx] = []
+                try:
+                    mask = cv2.imread(mask_path, cv2.IMREAD_GRAYSCALE)
+                    if mask is not None:
+                        frame_masks[frame_idx].append(mask)
+                except Exception as e:
+                    logger.warning(f"Failed to load mask {mask_path}: {e}")
+
+        # Project points to each frame
+        for frame_idx in range(len(frames)):
+            if frame_idx not in frame_masks or not frame_masks[frame_idx]:
+                continue
+
+            # Get camera matrices
+            c2w = cam_c2w[frame_idx]
+            w2c = np.linalg.inv(c2w)
+
+            # Project 3D points to camera space
+            xyz_cam = (w2c[:3, :3] @ xyz.T + w2c[:3, 3:4]).T
+            z = xyz_cam[:, 2]
+            valid = z > 0.1  # Points in front of camera
+
+            # Project to image
+            uv = (intrinsic @ xyz_cam.T).T
+            uv = uv[:, :2] / (uv[:, 2:3] + 1e-8)
+
+            # Check mask coverage
+            for mask in frame_masks[frame_idx]:
+                h, w = mask.shape
+                in_frame = (
+                    (uv[:, 0] >= 0)
+                    & (uv[:, 0] < w)
+                    & (uv[:, 1] >= 0)
+                    & (uv[:, 1] < h)
+                    & valid
+                )
+
+                in_frame_indices = np.where(in_frame)[0]
+                if len(in_frame_indices) == 0:
+                    continue
+
+                u_int = uv[in_frame, 0].astype(int)
+                v_int = uv[in_frame, 1].astype(int)
+
+                # Check if in mask
+                in_mask = mask[v_int, u_int] > 127
+                motion_counts[in_frame_indices[in_mask]] += 1
+
+            visible_counts[valid] += 1
+
+        # Compute probability
+        valid_visible = visible_counts > 0
+        prob_motion = np.zeros_like(motion_counts)
+        prob_motion[valid_visible] = (
+            motion_counts[valid_visible] / visible_counts[valid_visible]
+        )
+
+        return prob_motion
+
+    def _assign_timestamps(
+        self,
+        xyz: np.ndarray,
+        prob_motion: np.ndarray,
+        num_frames: int,
+        options: Instant4DOptions,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Assign temporal coordinates to points.
+
+        Static points get fixed timestamp at midpoint.
+        Dynamic points get timestamps spread across time range.
+        """
+        t_min, t_max = options.time_duration
+        t_mid = (t_min + t_max) / 2
+        t_range = t_max - t_min
+
+        num_points = xyz.shape[0]
+        time_stamp = np.full(num_points, t_mid, dtype=np.float32)
+        scale_time = np.full(num_points, t_range / 2, dtype=np.float32)
+
+        # Dynamic points: spread across time
+        dynamic_mask = prob_motion > options.motion_threshold
+        num_dynamic = np.sum(dynamic_mask)
+
+        if num_dynamic > 0:
+            # Assign timestamps uniformly
+            time_stamp[dynamic_mask] = np.random.uniform(
+                t_min, t_max, num_dynamic
+            ).astype(np.float32)
+            # Smaller temporal scale for dynamic
+            scale_time[dynamic_mask] = t_range / 4
+
+        return time_stamp, scale_time
+
+    def _voxel_filter(
+        self,
+        xyz: np.ndarray,
+        rgb: np.ndarray,
+        prob_motion: np.ndarray,
+        time_stamp: np.ndarray,
+        scale_time: np.ndarray,
+        intrinsic: np.ndarray,
+        cam_c2w: np.ndarray,
+        options: Instant4DOptions,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Apply voxel-based grid pruning to reduce point count.
+
+        Uses different voxel sizes for static vs dynamic regions.
+        """
+        try:
+            import point_cloud_utils as pcu
+        except ImportError:
+            logger.warning(
+                "point_cloud_utils not available. Skipping voxel filtering. "
+                "Install with: pip install point-cloud-utils"
+            )
+            return xyz, rgb, prob_motion, time_stamp, scale_time
+
+        # Compute mean depth for voxel size
+        focal = intrinsic[0, 0]
+        camera_centers = cam_c2w[:, :3, 3]
+        mean_depth = np.linalg.norm(xyz.mean(axis=0) - camera_centers.mean(axis=0))
+
+        # Split static/dynamic
+        dynamic_mask = prob_motion > options.motion_threshold
+        static_mask = ~dynamic_mask
+
+        filtered_indices = []
+
+        # Filter static points
+        if np.any(static_mask):
+            voxel_size = mean_depth / focal * options.static_voxel_scale
+            static_xyz = xyz[static_mask]
+            static_indices = np.where(static_mask)[0]
+
+            # Downsample
+            _, indices = pcu.downsample_point_cloud_voxel_grid(
+                voxel_size, static_xyz, return_indices=True
+            )
+            filtered_indices.extend(static_indices[indices])
+
+        # Filter dynamic points
+        if np.any(dynamic_mask):
+            voxel_size = mean_depth / focal * options.dynamic_voxel_scale
+            dynamic_xyz = xyz[dynamic_mask]
+            dynamic_indices = np.where(dynamic_mask)[0]
+
+            # Downsample
+            _, indices = pcu.downsample_point_cloud_voxel_grid(
+                voxel_size, dynamic_xyz, return_indices=True
+            )
+            filtered_indices.extend(dynamic_indices[indices])
+
+        # Apply filter
+        filtered_indices = np.array(filtered_indices)
+        return (
+            xyz[filtered_indices],
+            rgb[filtered_indices],
+            prob_motion[filtered_indices],
+            time_stamp[filtered_indices],
+            scale_time[filtered_indices],
+        )
+
+    def _create_instant4d_transforms(
+        self,
+        transforms: Dict[str, Any],
+        frames_dir: str,
+        output_path: Path,
+        num_frames: int,
+    ) -> None:
+        """Create transforms_train.json and transforms_test.json for Instant4D."""
+        frames = transforms["frames"]
+
+        # Split 90/10 train/test
+        train_count = int(num_frames * 0.9)
+        train_frames = frames[:train_count]
+        test_frames = frames[train_count:]
+
+        # Add timestamp to each frame
+        for i, frame in enumerate(frames):
+            frame["time"] = i / max(1, num_frames - 1) * 3.0  # Normalize to [0, 3]
+
+        # Create base structure
+        base = {
+            "fl_x": transforms.get("fl_x", 500),
+            "fl_y": transforms.get("fl_y", transforms.get("fl_x", 500)),
+            "cx": transforms.get("cx", transforms.get("w", 640) / 2),
+            "cy": transforms.get("cy", transforms.get("h", 480) / 2),
+            "w": transforms.get("w", 640),
+            "h": transforms.get("h", 480),
+        }
+
+        # Write train transforms
+        train_data = {**base, "frames": train_frames}
+        with open(output_path / "transforms_train.json", "w") as f:
+            json.dump(train_data, f, indent=2)
+
+        # Write test transforms
+        test_data = {**base, "frames": test_frames if test_frames else train_frames[:1]}
+        with open(output_path / "transforms_test.json", "w") as f:
+            json.dump(test_data, f, indent=2)
+
+    def _build_training_config(
+        self, preprocessed_dir: str, output_path: Path, options: Instant4DOptions
+    ) -> Tuple[Any, Any, Any]:
+        """Build Instant4D training configuration objects."""
+        from argparse import Namespace
+
+        # Model parameters
+        model_params = Namespace(
+            source_path=preprocessed_dir,
+            model_path=str(output_path),
+            sh_degree=0,
+            images="images",
+            resolution=1,
+            white_background=False,
+            data_device="cuda",
+            eval=False,
+        )
+
+        # Optimization parameters
+        opt_params = Namespace(
+            iterations=options.iterations,
+            position_lr_init=0.00016,
+            position_lr_final=0.0000016,
+            position_lr_delay_mult=0.01,
+            position_lr_max_steps=30000,
+            feature_lr=0.0025,
+            opacity_lr=0.05,
+            scaling_lr=0.005,
+            rotation_lr=0.001,
+            densify_from_iter=500,
+            densify_until_iter=min(15000, options.iterations),
+            densify_grad_threshold=0.0002,
+            densification_interval=100,
+            opacity_reset_interval=3000,
+            thresh_opa_prune=0.005,
+            percent_dense=0.01,
+            lambda_dssim=0.2,
+        )
+
+        # Pipeline parameters
+        pipe_params = Namespace(
+            convert_SHs_python=False,
+            compute_cov3D_python=False,
+            debug=False,
+        )
+
+        return model_params, opt_params, pipe_params
+
+    def _compute_loss(self, image: "torch.Tensor", gt_image: "torch.Tensor") -> "torch.Tensor":
+        """Compute training loss (L1 + SSIM)."""
+        import torch
+        import torch.nn.functional as F
+
+        # L1 loss
+        l1_loss = F.l1_loss(image, gt_image)
+
+        # Simple SSIM approximation (use fused_ssim if available)
+        try:
+            from fused_ssim import fused_ssim
+
+            ssim_loss = 1 - fused_ssim(
+                image.unsqueeze(0), gt_image.unsqueeze(0), padding="same"
+            )
+        except ImportError:
+            # Fallback: just use L1
+            ssim_loss = torch.tensor(0.0, device=image.device)
+
+        return 0.8 * l1_loss + 0.2 * ssim_loss
+
+    def _compute_psnr(self, image: "torch.Tensor", gt_image: "torch.Tensor") -> float:
+        """Compute PSNR between rendered and ground truth images."""
+        import torch
+
+        mse = torch.mean((image - gt_image) ** 2)
+        if mse == 0:
+            return float("inf")
+        return (10 * torch.log10(1.0 / mse)).item()
+
+    def _compute_final_metrics(
+        self, scene: Any, gaussians: Any, pipe_params: Any, bg_color: "torch.Tensor"
+    ) -> Dict[str, Any]:
+        """Compute final evaluation metrics on test views."""
+        import torch
+        from gaussian_renderer import render
+
+        test_cameras = scene.getTestCameras()
+        if not test_cameras:
+            return {"psnr": 0.0, "ssim": 0.0, "num_test_views": 0}
+
+        psnr_values = []
+
+        with torch.no_grad():
+            for viewpoint in test_cameras[:5]:  # Limit to 5 test views
+                render_pkg = render(viewpoint, gaussians, pipe_params, bg_color)
+                image = render_pkg["render"]
+                gt_image = viewpoint.original_image.cuda()
+                psnr = self._compute_psnr(image, gt_image)
+                psnr_values.append(psnr)
+
+        return {
+            "psnr": float(np.mean(psnr_values)) if psnr_values else 0.0,
+            "num_test_views": len(psnr_values),
+            "num_gaussians": gaussians.get_xyz.shape[0],
+        }
+
+    def _load_model(self, model_path: str) -> Any:
+        """Load trained Gaussian model from checkpoint."""
+        import torch
+
+        self._add_instant4d_to_path()
+        from scene.gaussian_model import GaussianModel
+
+        # Load checkpoint
+        checkpoint = torch.load(model_path, map_location="cuda")
+
+        # Infer model parameters from checkpoint
+        sh_degree = checkpoint.get("active_sh_degree", 0)
+
+        # Create model
+        gaussians = GaussianModel(
+            sh_degree=sh_degree,
+            gaussian_dim=4,
+            time_duration=[0.0, 3.0],
+            rot_4d=True,
+            force_sh_3d=False,
+        )
+
+        # Restore state
+        gaussians.restore(checkpoint, None)
+
+        return gaussians
+
+    def _save_config(self, config_path: Path, options: Instant4DOptions) -> None:
+        """Save training configuration to YAML."""
+        import yaml
+
+        config = {
+            "iterations": options.iterations,
+            "batch_size": options.batch_size,
+            "gaussian_dim": options.gaussian_dim,
+            "time_duration": list(options.time_duration),
+            "rot_4d": options.rot_4d,
+            "num_pts": options.num_pts,
+            "enable_pruning": options.enable_pruning,
+            "motion_threshold": options.motion_threshold,
+        }
+
+        with open(config_path, "w") as f:
+            yaml.dump(config, f)
+
+    def _write_ply(self, path: Path, xyz: np.ndarray, rgb: np.ndarray) -> None:
+        """Write point cloud to PLY file."""
+        try:
+            from plyfile import PlyData, PlyElement
+        except ImportError:
+            raise ImportError("plyfile required. Install with: pip install plyfile")
+
+        # Ensure rgb is uint8
+        if rgb.dtype != np.uint8:
+            rgb = np.clip(rgb, 0, 255).astype(np.uint8)
+
+        # Create structured array
+        dtype = [
+            ("x", "f4"),
+            ("y", "f4"),
+            ("z", "f4"),
+            ("nx", "f4"),
+            ("ny", "f4"),
+            ("nz", "f4"),
+            ("red", "u1"),
+            ("green", "u1"),
+            ("blue", "u1"),
+        ]
+
+        normals = np.zeros_like(xyz)
+        elements = np.empty(xyz.shape[0], dtype=dtype)
+
+        for i in range(xyz.shape[0]):
+            elements[i] = (
+                xyz[i, 0],
+                xyz[i, 1],
+                xyz[i, 2],
+                normals[i, 0],
+                normals[i, 1],
+                normals[i, 2],
+                rgb[i, 0],
+                rgb[i, 1],
+                rgb[i, 2],
+            )
+
+        vertex = PlyElement.describe(elements, "vertex")
+        PlyData([vertex]).write(str(path))

--- a/backend/stages/gaussian_training.py
+++ b/backend/stages/gaussian_training.py
@@ -1,18 +1,32 @@
-"""Stage 3: 3D Gaussian Splatting Training."""
+"""Stage 3: 4D Gaussian Splatting Training with Instant4D.
+
+This stage trains a 4D Gaussian Splatting model from processed video data,
+enabling temporal reconstruction where users can navigate in 3D while time
+progresses.
+
+Architecture Notes:
+    - Uses Instant4DAdapter internally (not exposed in ADAPTERS registry)
+    - Accepts optional ObjectSegmentationResult from Stage 2 for dynamic/static separation
+    - Outputs per-frame PLY files for Stage 5 (Web Export)
+"""
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Callable
+from typing import Optional, Callable, List
+import logging
 
 from .video_processing import VideoProcessingResult
+from .object_segmentation import ObjectSegmentationResult
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class GaussianTrainingResult:
-    """Result of 3DGS training stage."""
+    """Result of 4D Gaussian training stage."""
 
     ply_path: str
-    """Path to trained Gaussian splat PLY file."""
+    """Path to first PLY file (for backward compatibility)."""
 
     num_gaussians: int
     """Number of Gaussians in the trained model."""
@@ -21,103 +35,160 @@ class GaussianTrainingResult:
     """Quality metrics (PSNR, SSIM, etc.)."""
 
     config_path: Optional[str] = None
-    """Path to Nerfstudio config file."""
+    """Path to training configuration file."""
+
+    # New fields for 4D support
+    ply_paths: List[str] = field(default_factory=list)
+    """Paths to all per-frame PLY files (for 4D reconstruction)."""
+
+    model_path: Optional[str] = None
+    """Path to trained 4D model checkpoint (.pth)."""
+
+    num_frames: int = 0
+    """Number of temporal frames extracted."""
+
+    temporal_metadata: dict = field(default_factory=dict)
+    """Temporal metadata (fps, duration, timestamps)."""
 
 
 class GaussianTrainingStage:
     """
-    Stage 3: Train 3D Gaussian Splatting model from processed video data.
+    Stage 3: Train 4D Gaussian Splatting model from processed video data.
 
-    This stage:
-    1. Initializes Gaussians from sparse point cloud
-    2. Trains using Nerfstudio's Splatfacto
-    3. Exports trained model to PLY format
+    This stage uses Instant4D to create a true 4D reconstruction that supports
+    temporal playback - users can navigate in 3D space while time progresses.
 
-    Output: scene.ply, quality_metrics.json
+    Pipeline:
+    1. Preprocess Stage 1/2 outputs to Instant4D format
+    2. Apply voxel-based grid pruning (92% Gaussian reduction)
+    3. Train 4D Gaussians (~2-5 minutes)
+    4. Export per-frame PLY files for web viewing
+
+    Input:
+        - VideoProcessingResult from Stage 1 (frames + poses)
+        - ObjectSegmentationResult from Stage 2 (optional, for dynamic/static separation)
+
+    Output:
+        - Per-frame PLY files in output_dir/plys/
+        - Trained 4D model checkpoint
+        - Quality metrics (PSNR, SSIM)
+
+    Requirements:
+        - CUDA 12.1+ with compiled Instant4D kernels
+        - ~24GB VRAM for training
     """
 
-    def __init__(self, config: dict = None):
+    def __init__(self, config: Optional[dict] = None):
+        """
+        Initialize Gaussian training stage.
+
+        Args:
+            config: Configuration dictionary with keys:
+                - iterations: Training iterations (default: 5000)
+                - device: CUDA device (default: "cuda:0")
+                - enable_pruning: Enable voxel pruning (default: True)
+                - motion_threshold: Static/dynamic threshold (default: 0.5)
+        """
         self.config = config or {}
-        self.num_iterations = self.config.get("num_iterations", 30000)
-        self.method = self.config.get("method", "splatfacto")
+        self._adapter = None
+
+    def _get_adapter(self):
+        """Lazy-load Instant4DAdapter."""
+        if self._adapter is None:
+            from ..adapters.instant4d import Instant4DAdapter
+
+            self._adapter = Instant4DAdapter(self.config)
+        return self._adapter
 
     def train(
         self,
         processed: VideoProcessingResult,
         output_dir: str,
+        segmentation: Optional[ObjectSegmentationResult] = None,
         progress_callback: Optional[Callable[[float, str], None]] = None,
     ) -> GaussianTrainingResult:
         """
-        Train 3DGS model from processed video data.
+        Train 4D Gaussian model from processed video data.
 
         Args:
-            processed: Result from video processing stage.
+            processed: Result from video processing stage (Stage 1).
             output_dir: Directory to store outputs.
+            segmentation: Result from object segmentation stage (Stage 2), optional.
+                         If provided, enables dynamic/static region separation.
             progress_callback: Optional callback(progress, message).
 
         Returns:
-            GaussianTrainingResult with path to trained PLY.
-        """
+            GaussianTrainingResult with paths to trained model and PLY files.
 
-        def report(pct: float, msg: str):
+        Raises:
+            ImportError: If Instant4D is not properly installed.
+            RuntimeError: If training fails.
+        """
+        from ..adapters.instant4d import Instant4DOptions
+
+        def report(pct: float, msg: str) -> None:
             if progress_callback:
                 progress_callback(pct, msg)
+            logger.info(f"[{pct*100:.0f}%] {msg}")
 
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        report(0.0, "Initializing 3DGS training")
+        report(0.0, "Initializing 4D Gaussian training")
 
-        # Step 1: Prepare data in Nerfstudio format
-        report(0.05, "Preparing training data")
-        data_path = self._prepare_nerfstudio_data(processed, output_path)
-
-        # Step 2: Train Splatfacto
-        report(0.1, f"Training {self.method} ({self.num_iterations} iterations)")
-        config_path = self._train_splatfacto(data_path, output_path, progress_callback)
-
-        # Step 3: Export to PLY
-        report(0.95, "Exporting to PLY format")
-        ply_path = output_path / "scene.ply"
-        num_gaussians = self._export_ply(config_path, ply_path)
-
-        # Step 4: Compute quality metrics
-        metrics = self._compute_metrics(config_path)
-
-        report(1.0, "3DGS training complete")
-
-        return GaussianTrainingResult(
-            ply_path=str(ply_path),
-            num_gaussians=num_gaussians,
-            metrics=metrics,
-            config_path=str(config_path) if config_path else None,
+        # Build options from config
+        options = Instant4DOptions(
+            iterations=self.config.get("iterations", 5000),
+            enable_pruning=self.config.get("enable_pruning", True),
+            motion_threshold=self.config.get("motion_threshold", 0.5),
+            gaussian_dim=self.config.get("gaussian_dim", 4),
+            rot_4d=self.config.get("rot_4d", True),
         )
 
-    def _prepare_nerfstudio_data(self, processed: VideoProcessingResult, output_path: Path) -> Path:
-        """Prepare data in Nerfstudio format."""
-        # TODO: Convert transforms.json to Nerfstudio format if needed
-        # The transforms.json from hloc should already be compatible
-        raise NotImplementedError("Nerfstudio data preparation not yet implemented")
+        # Get adapter and run pipeline
+        adapter = self._get_adapter()
 
-    def _train_splatfacto(
-        self,
-        data_path: Path,
-        output_path: Path,
-        progress_callback: Optional[Callable[[float, str], None]] = None,
-    ) -> Path:
-        """Train Splatfacto model."""
-        # TODO: Implement Nerfstudio training
-        # ns-train splatfacto --data {data_path} --output-dir {output_path}
-        # with progress monitoring
-        raise NotImplementedError("Splatfacto training not yet implemented")
+        try:
+            report(0.02, "Running Instant4D pipeline")
+            result = adapter.run_full_pipeline(
+                video_result=processed,
+                segmentation_result=segmentation,
+                output_dir=str(output_path),
+                options=options,
+                progress_callback=lambda p, m: report(0.02 + p * 0.96, m),
+            )
 
-    def _export_ply(self, config_path: Path, ply_path: Path) -> int:
-        """Export trained model to PLY format."""
-        # TODO: Implement PLY export
-        # ns-export gaussian-splat --load-config {config_path} --output-dir {ply_path.parent}
-        raise NotImplementedError("PLY export not yet implemented")
+            report(0.98, "Finalizing results")
 
-    def _compute_metrics(self, config_path: Path) -> dict:
-        """Compute quality metrics on held-out views."""
-        # TODO: Load model and compute PSNR, SSIM, LPIPS
-        return {}
+            # Build result
+            training_result = GaussianTrainingResult(
+                # Backward compatibility: ply_path is first PLY
+                ply_path=result.ply_paths[0] if result.ply_paths else "",
+                num_gaussians=result.num_gaussians,
+                metrics=result.metrics,
+                config_path=result.config_path,
+                # New 4D fields
+                ply_paths=result.ply_paths,
+                model_path=result.model_path,
+                num_frames=result.num_frames,
+                temporal_metadata=result.temporal_metadata,
+            )
+
+            report(1.0, f"4D training complete: {result.num_frames} frames, "
+                       f"{result.num_gaussians} Gaussians")
+
+            return training_result
+
+        except Exception as e:
+            logger.error(f"Training failed: {e}")
+            raise RuntimeError(f"4D Gaussian training failed: {e}") from e
+
+        finally:
+            # Cleanup to release GPU memory
+            adapter.cleanup()
+
+    def cleanup(self) -> None:
+        """Release resources."""
+        if self._adapter is not None:
+            self._adapter.cleanup()
+            self._adapter = None

--- a/tests/adapters/__init__.py
+++ b/tests/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for backend adapters."""

--- a/tests/adapters/test_instant4d_adapter.py
+++ b/tests/adapters/test_instant4d_adapter.py
@@ -1,0 +1,742 @@
+"""Tests for Instant4D adapter.
+
+These tests verify the Instant4D adapter for 4D Gaussian Splatting reconstruction.
+
+Usage:
+    # Run all tests (CPU-only tests will pass on Mac)
+    pytest tests/adapters/test_instant4d_adapter.py -v
+
+    # Run only preprocessing tests
+    pytest tests/adapters/test_instant4d_adapter.py::TestPreprocessing -v
+
+    # Run GPU tests (on GPU server only)
+    pytest tests/adapters/test_instant4d_adapter.py -v -m gpu
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# Test fixtures and mocks
+
+
+@pytest.fixture
+def mock_transforms():
+    """Create mock transforms.json content."""
+    return {
+        "fl_x": 500.0,
+        "fl_y": 500.0,
+        "cx": 320.0,
+        "cy": 240.0,
+        "w": 640,
+        "h": 480,
+        "frames": [
+            {
+                "file_path": f"./frames/{i:04d}.jpg",
+                "transform_matrix": np.eye(4).tolist(),
+            }
+            for i in range(10)
+        ],
+    }
+
+
+@pytest.fixture
+def mock_video_result(tmp_path, mock_transforms):
+    """Create mock VideoProcessingResult."""
+    from backend.stages.video_processing import VideoProcessingResult
+
+    # Create frames directory
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+
+    # Create dummy frames (just empty files)
+    for i in range(10):
+        (frames_dir / f"{i:04d}.jpg").touch()
+
+    # Create transforms.json
+    transforms_path = tmp_path / "transforms.json"
+    with open(transforms_path, "w") as f:
+        json.dump(mock_transforms, f)
+
+    # Create sparse points PLY (minimal valid PLY)
+    sparse_path = tmp_path / "sparse" / "points3D.ply"
+    sparse_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Create a minimal PLY file
+    ply_content = """ply
+format ascii 1.0
+element vertex 100
+property float x
+property float y
+property float z
+property uchar red
+property uchar green
+property uchar blue
+end_header
+"""
+    for _ in range(100):
+        x, y, z = np.random.randn(3)
+        r, g, b = np.random.randint(0, 256, 3)
+        ply_content += f"{x} {y} {z} {r} {g} {b}\n"
+
+    with open(sparse_path, "w") as f:
+        f.write(ply_content)
+
+    return VideoProcessingResult(
+        frames_dir=str(frames_dir),
+        num_frames=10,
+        transforms_path=str(transforms_path),
+        sparse_points_path=str(sparse_path),
+        metadata={"fps": 30, "width": 640, "height": 480},
+    )
+
+
+@pytest.fixture
+def mock_segmentation_result(tmp_path):
+    """Create mock ObjectSegmentationResult."""
+    from backend.stages.object_segmentation import (
+        ObjectSegmentationResult,
+        SegmentedObject,
+    )
+
+    # Create masks directory
+    masks_dir = tmp_path / "masks"
+    masks_dir.mkdir()
+
+    # Create dummy object
+    obj = SegmentedObject(
+        object_id=1,
+        label="person",
+        mask_paths=[],
+        frame_indices=list(range(10)),
+        confidence=0.95,
+    )
+
+    # Create dummy masks
+    for i in range(10):
+        mask_path = masks_dir / f"obj1_frame{i:04d}.png"
+        # Create a simple binary mask (black image with white rectangle)
+        mask_data = np.zeros((480, 640), dtype=np.uint8)
+        mask_data[200:300, 250:400] = 255
+        # Save as grayscale PNG
+        try:
+            import cv2
+
+            cv2.imwrite(str(mask_path), mask_data)
+        except ImportError:
+            # Fallback: create empty file if cv2 not available
+            mask_path.touch()
+        obj.mask_paths.append(str(mask_path))
+
+    # Create metadata
+    metadata = {
+        "num_objects": 1,
+        "objects": [
+            {
+                "object_id": 1,
+                "label": "person",
+                "frame_count": 10,
+            }
+        ],
+    }
+    metadata_path = masks_dir / "object_metadata.json"
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f)
+
+    return ObjectSegmentationResult(
+        masks_dir=str(masks_dir),
+        num_objects=1,
+        objects=[obj],
+        metadata_path=str(metadata_path),
+        metadata=metadata,
+    )
+
+
+# =============================================================================
+# Test Classes
+# =============================================================================
+
+
+class TestInstant4DOptions:
+    """Test Instant4DOptions dataclass."""
+
+    def test_default_values(self):
+        """Default options have expected values."""
+        from backend.adapters.instant4d import Instant4DOptions
+
+        options = Instant4DOptions()
+
+        assert options.iterations == 5000
+        assert options.batch_size == 1
+        assert options.gaussian_dim == 4
+        assert options.time_duration == (0.0, 3.0)
+        assert options.rot_4d is True
+        assert options.enable_pruning is True
+        assert options.motion_threshold == 0.5
+
+    def test_custom_values(self):
+        """Custom options are set correctly."""
+        from backend.adapters.instant4d import Instant4DOptions
+
+        options = Instant4DOptions(
+            iterations=10000,
+            gaussian_dim=3,
+            rot_4d=False,
+        )
+
+        assert options.iterations == 10000
+        assert options.gaussian_dim == 3
+        assert options.rot_4d is False
+
+
+class TestInstant4DResult:
+    """Test Instant4DResult dataclass."""
+
+    def test_default_values(self):
+        """Default result has expected empty values."""
+        from backend.adapters.instant4d import Instant4DResult
+
+        result = Instant4DResult(model_path="/path/to/model.pth")
+
+        assert result.model_path == "/path/to/model.pth"
+        assert result.ply_paths == []
+        assert result.num_gaussians == 0
+        assert result.num_frames == 0
+        assert result.metrics == {}
+        assert result.config_path is None
+
+    def test_full_result(self):
+        """Full result with all fields."""
+        from backend.adapters.instant4d import Instant4DResult
+
+        result = Instant4DResult(
+            model_path="/path/to/model.pth",
+            ply_paths=["/path/to/frame_0000.ply", "/path/to/frame_0001.ply"],
+            num_gaussians=50000,
+            num_frames=30,
+            metrics={"psnr": 28.5, "ssim": 0.92},
+            config_path="/path/to/config.yaml",
+            temporal_metadata={"fps": 30, "duration_seconds": 1.0},
+        )
+
+        assert len(result.ply_paths) == 2
+        assert result.num_gaussians == 50000
+        assert result.metrics["psnr"] == 28.5
+
+
+class TestInstant4DAdapterInit:
+    """Test Instant4DAdapter initialization."""
+
+    def test_init_default(self):
+        """Adapter initializes with default config."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        # This may fail if Instant4D submodule is not initialized
+        try:
+            adapter = Instant4DAdapter()
+            assert adapter.device == "cuda:0"
+            assert adapter._gaussian_model is None
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_init_custom_device(self):
+        """Adapter accepts custom device."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        try:
+            adapter = Instant4DAdapter({"device": "cuda:1"})
+            assert adapter.device == "cuda:1"
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_instant4d_path_exists(self):
+        """Instant4D submodule path is correct."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        path = Instant4DAdapter.INSTANT4D_PATH
+        # This checks the path calculation is correct
+        assert "instant4d" in str(path).lower()
+
+
+class TestPreprocessing:
+    """Test preprocessing functions."""
+
+    def test_load_transforms(self, tmp_path, mock_transforms):
+        """Transforms are loaded correctly."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        # Write transforms
+        transforms_path = tmp_path / "transforms.json"
+        with open(transforms_path, "w") as f:
+            json.dump(mock_transforms, f)
+
+        try:
+            adapter = Instant4DAdapter()
+            transforms = adapter._load_transforms(str(transforms_path))
+
+            assert "frames" in transforms
+            assert len(transforms["frames"]) == 10
+            assert transforms["fl_x"] == 500.0
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_extract_intrinsics_fl_format(self, mock_transforms):
+        """Intrinsics extracted from fl_x/fl_y format."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        try:
+            adapter = Instant4DAdapter()
+            intrinsic = adapter._extract_intrinsics(mock_transforms)
+
+            assert intrinsic.shape == (3, 3)
+            assert intrinsic[0, 0] == 500.0  # fl_x
+            assert intrinsic[1, 1] == 500.0  # fl_y
+            assert intrinsic[0, 2] == 320.0  # cx
+            assert intrinsic[1, 2] == 240.0  # cy
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_extract_intrinsics_angle_format(self):
+        """Intrinsics extracted from camera_angle_x format."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        transforms = {
+            "camera_angle_x": 1.0,  # ~57 degrees
+            "w": 640,
+            "h": 480,
+            "frames": [],
+        }
+
+        try:
+            adapter = Instant4DAdapter()
+            intrinsic = adapter._extract_intrinsics(transforms)
+
+            assert intrinsic.shape == (3, 3)
+            assert intrinsic[0, 2] == 320.0  # cx = w/2
+            assert intrinsic[1, 2] == 240.0  # cy = h/2
+            # fl_x = w / (2 * tan(angle/2))
+            expected_fl = 640 / (2 * np.tan(1.0 / 2))
+            assert abs(intrinsic[0, 0] - expected_fl) < 0.1
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_convert_poses_opengl_to_colmap(self, mock_transforms):
+        """Pose conversion flips Y and Z axes."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        # Create frames with known poses
+        frames = [
+            {"transform_matrix": np.eye(4).tolist()},
+            {
+                "transform_matrix": [
+                    [1, 0, 0, 1],
+                    [0, 1, 0, 2],
+                    [0, 0, 1, 3],
+                    [0, 0, 0, 1],
+                ]
+            },
+        ]
+
+        try:
+            adapter = Instant4DAdapter()
+            cam_c2w = adapter._convert_poses_nerfstudio_to_instant4d(frames)
+
+            assert cam_c2w.shape == (2, 4, 4)
+            # First pose: identity should have Y and Z columns flipped
+            # Original OpenGL Y-axis becomes -Y
+            # Original OpenGL Z-axis becomes -Z
+            assert cam_c2w[0, 0, 0] == 1  # X unchanged
+            assert cam_c2w[0, 1, 1] == -1  # Y flipped
+            assert cam_c2w[0, 2, 2] == -1  # Z flipped
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_load_sparse_points(self, mock_video_result):
+        """Sparse points loaded from PLY."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        try:
+            adapter = Instant4DAdapter()
+            xyz, rgb = adapter._load_sparse_points(mock_video_result.sparse_points_path)
+
+            assert xyz.shape[0] == 100  # 100 points
+            assert xyz.shape[1] == 3  # XYZ
+            assert rgb.shape[0] == 100
+            assert rgb.shape[1] == 3  # RGB
+            assert rgb.max() <= 1.0  # Normalized to [0, 1]
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_assign_timestamps_static(self):
+        """Static points get midpoint timestamp."""
+        from backend.adapters.instant4d import Instant4DAdapter, Instant4DOptions
+
+        xyz = np.random.randn(100, 3).astype(np.float32)
+        prob_motion = np.zeros(100, dtype=np.float32)  # All static
+        options = Instant4DOptions(time_duration=(0.0, 3.0))
+
+        try:
+            adapter = Instant4DAdapter()
+            time_stamp, scale_time = adapter._assign_timestamps(
+                xyz, prob_motion, 30, options
+            )
+
+            assert time_stamp.shape == (100,)
+            # Static points should be at midpoint
+            assert np.allclose(time_stamp, 1.5)
+            # Scale should be half the range
+            assert np.allclose(scale_time, 1.5)
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_assign_timestamps_dynamic(self):
+        """Dynamic points get varied timestamps."""
+        from backend.adapters.instant4d import Instant4DAdapter, Instant4DOptions
+
+        xyz = np.random.randn(100, 3).astype(np.float32)
+        prob_motion = np.ones(100, dtype=np.float32)  # All dynamic
+        options = Instant4DOptions(time_duration=(0.0, 3.0), motion_threshold=0.5)
+
+        try:
+            adapter = Instant4DAdapter()
+            time_stamp, scale_time = adapter._assign_timestamps(
+                xyz, prob_motion, 30, options
+            )
+
+            assert time_stamp.shape == (100,)
+            # Dynamic points should be spread across time range
+            assert time_stamp.min() >= 0.0
+            assert time_stamp.max() <= 3.0
+            # Timestamps should vary
+            assert time_stamp.std() > 0.1
+            # Dynamic scale should be smaller
+            assert np.allclose(scale_time, 0.75)  # t_range / 4
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+
+class TestFormatConversion:
+    """Test data format conversions."""
+
+    def test_transforms_json_round_trip(self, tmp_path, mock_transforms):
+        """Transforms survive round-trip conversion."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        try:
+            adapter = Instant4DAdapter()
+
+            # Write original
+            input_path = tmp_path / "input"
+            input_path.mkdir()
+            transforms_path = input_path / "transforms.json"
+            with open(transforms_path, "w") as f:
+                json.dump(mock_transforms, f)
+
+            # Create output directory
+            output_path = tmp_path / "output"
+            output_path.mkdir()
+
+            # Create Instant4D transforms
+            adapter._create_instant4d_transforms(
+                mock_transforms, str(input_path / "frames"), output_path, 10
+            )
+
+            # Verify train and test transforms exist
+            assert (output_path / "transforms_train.json").exists()
+            assert (output_path / "transforms_test.json").exists()
+
+            # Load and verify train transforms
+            with open(output_path / "transforms_train.json") as f:
+                train_data = json.load(f)
+
+            assert "frames" in train_data
+            assert "fl_x" in train_data
+            # Train should have 90% of frames
+            assert len(train_data["frames"]) == 9
+
+            # Frames should have timestamps
+            assert "time" in train_data["frames"][0]
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_timestamp_normalization(self, tmp_path, mock_transforms):
+        """Timestamps normalized to [0, 3] range."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        try:
+            adapter = Instant4DAdapter()
+            output_path = tmp_path / "output"
+            output_path.mkdir()
+
+            adapter._create_instant4d_transforms(
+                mock_transforms, str(tmp_path / "frames"), output_path, 10
+            )
+
+            with open(output_path / "transforms_train.json") as f:
+                train_data = json.load(f)
+
+            timestamps = [f["time"] for f in train_data["frames"]]
+            assert min(timestamps) >= 0.0
+            assert max(timestamps) <= 3.0
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+
+class TestPLYExport:
+    """Test PLY file writing."""
+
+    def test_write_ply(self, tmp_path):
+        """PLY file is written correctly."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        xyz = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]], dtype=np.float32)
+        rgb = np.array([[255, 0, 0], [0, 255, 0], [0, 0, 255]], dtype=np.uint8)
+        ply_path = tmp_path / "test.ply"
+
+        try:
+            adapter = Instant4DAdapter()
+            adapter._write_ply(ply_path, xyz, rgb)
+
+            # Verify file exists
+            assert ply_path.exists()
+
+            # Verify can be read back
+            from plyfile import PlyData
+
+            plydata = PlyData.read(str(ply_path))
+            vertex = plydata["vertex"]
+
+            assert len(vertex) == 3
+            assert vertex["x"][0] == 0
+            assert vertex["red"][0] == 255
+        except ImportError as e:
+            pytest.skip(f"Required package not available: {e}")
+
+
+class TestGaussianTrainingStage:
+    """Test GaussianTrainingStage integration."""
+
+    def test_stage_init(self):
+        """Stage initializes correctly."""
+        from backend.stages.gaussian_training import GaussianTrainingStage
+
+        stage = GaussianTrainingStage()
+        assert stage.config == {}
+        assert stage._adapter is None
+
+    def test_stage_with_config(self):
+        """Stage accepts config."""
+        from backend.stages.gaussian_training import GaussianTrainingStage
+
+        config = {"iterations": 10000, "device": "cuda:1"}
+        stage = GaussianTrainingStage(config)
+
+        assert stage.config["iterations"] == 10000
+        assert stage.config["device"] == "cuda:1"
+
+    def test_result_backward_compatibility(self):
+        """GaussianTrainingResult maintains backward compatibility."""
+        from backend.stages.gaussian_training import GaussianTrainingResult
+
+        # Old-style result with just ply_path
+        result = GaussianTrainingResult(
+            ply_path="/path/to/scene.ply",
+            num_gaussians=50000,
+        )
+
+        assert result.ply_path == "/path/to/scene.ply"
+        assert result.num_gaussians == 50000
+        # New fields should have defaults
+        assert result.ply_paths == []
+        assert result.model_path is None
+        assert result.num_frames == 0
+
+    def test_result_4d_fields(self):
+        """GaussianTrainingResult includes 4D fields."""
+        from backend.stages.gaussian_training import GaussianTrainingResult
+
+        result = GaussianTrainingResult(
+            ply_path="/path/to/frame_0000.ply",
+            num_gaussians=50000,
+            ply_paths=[f"/path/to/frame_{i:04d}.ply" for i in range(30)],
+            model_path="/path/to/model.pth",
+            num_frames=30,
+            temporal_metadata={"fps": 30, "duration_seconds": 1.0},
+        )
+
+        assert len(result.ply_paths) == 30
+        assert result.model_path == "/path/to/model.pth"
+        assert result.num_frames == 30
+        assert result.temporal_metadata["fps"] == 30
+
+
+# =============================================================================
+# GPU Tests (require CUDA)
+# =============================================================================
+
+
+@pytest.mark.gpu
+class TestTrainingGPU:
+    """GPU tests for training (run on server only)."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_no_cuda(self):
+        """Skip tests if CUDA is not available."""
+        try:
+            import torch
+
+            if not torch.cuda.is_available():
+                pytest.skip("CUDA not available")
+        except ImportError:
+            pytest.skip("PyTorch not installed")
+
+    def test_cuda_kernels_available(self):
+        """CUDA kernels are importable."""
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        try:
+            adapter = Instant4DAdapter()
+            adapter._validate_cuda_kernels()
+        except ImportError as e:
+            pytest.fail(f"CUDA kernels not available: {e}")
+
+    def test_training_basic(self, mock_video_result, tmp_path):
+        """Basic training completes without error."""
+        from backend.adapters.instant4d import Instant4DAdapter, Instant4DOptions
+
+        try:
+            adapter = Instant4DAdapter()
+
+            # Preprocess with minimal settings
+            options = Instant4DOptions(
+                iterations=100,  # Very short for testing
+                num_pts=1000,
+                enable_pruning=False,
+            )
+
+            # Run preprocessing
+            preprocessed_dir = adapter.preprocess(
+                mock_video_result,
+                None,  # No segmentation
+                str(tmp_path / "preprocessed"),
+                options,
+            )
+
+            assert (preprocessed_dir / "filtered_cvd.npz").exists()
+            assert (preprocessed_dir / "transforms_train.json").exists()
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+
+@pytest.mark.gpu
+class TestExportGPU:
+    """GPU tests for PLY export."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_no_cuda(self):
+        """Skip tests if CUDA is not available."""
+        try:
+            import torch
+
+            if not torch.cuda.is_available():
+                pytest.skip("CUDA not available")
+        except ImportError:
+            pytest.skip("PyTorch not installed")
+
+    def test_per_frame_ply_export_mock(self, tmp_path):
+        """Per-frame PLY export with mocked model."""
+        # This test would require a trained model
+        # For now, just verify the method signature works
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        try:
+            adapter = Instant4DAdapter()
+            # Would need actual model for full test
+            # adapter.extract_per_frame_ply(...)
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+
+class TestPipelineIntegration:
+    """Integration tests for full pipeline."""
+
+    def test_full_pipeline_mock_inputs(self, mock_video_result, tmp_path):
+        """Pipeline runs with mock inputs (preprocessing only, no GPU)."""
+        from backend.adapters.instant4d import Instant4DAdapter, Instant4DOptions
+
+        try:
+            adapter = Instant4DAdapter()
+            options = Instant4DOptions(enable_pruning=False)
+
+            # Only test preprocessing (doesn't require GPU)
+            preprocessed_dir = adapter.preprocess(
+                mock_video_result,
+                None,
+                str(tmp_path / "preprocessed"),
+                options,
+            )
+
+            # Verify outputs
+            assert (preprocessed_dir / "filtered_cvd.npz").exists()
+            assert (preprocessed_dir / "transforms_train.json").exists()
+            assert (preprocessed_dir / "transforms_test.json").exists()
+
+            # Load and verify npz content
+            data = np.load(preprocessed_dir / "filtered_cvd.npz")
+            assert "xyz" in data
+            assert "rgb" in data
+            assert "prob_motion" in data
+            assert "time_stamp" in data
+            assert "intrinsic" in data
+            assert "cam_c2w" in data
+
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_stage3_adapter_compatibility(self, mock_video_result, tmp_path):
+        """GaussianTrainingStage uses Instant4DAdapter correctly."""
+        from backend.stages.gaussian_training import GaussianTrainingStage
+
+        stage = GaussianTrainingStage({"iterations": 100})
+
+        # Verify adapter is created lazily
+        assert stage._adapter is None
+
+        try:
+            adapter = stage._get_adapter()
+            assert adapter is not None
+            assert stage._adapter is adapter
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_with_segmentation(
+        self, mock_video_result, mock_segmentation_result, tmp_path
+    ):
+        """Pipeline handles segmentation input."""
+        from backend.adapters.instant4d import Instant4DAdapter, Instant4DOptions
+
+        try:
+            adapter = Instant4DAdapter()
+            options = Instant4DOptions(enable_pruning=False)
+
+            preprocessed_dir = adapter.preprocess(
+                mock_video_result,
+                mock_segmentation_result,
+                str(tmp_path / "preprocessed"),
+                options,
+            )
+
+            # Load and verify prob_motion is non-zero
+            data = np.load(preprocessed_dir / "filtered_cvd.npz")
+            # With masks, some points may have motion probability > 0
+            # (depends on whether masks overlap with points)
+            assert "prob_motion" in data
+            assert data["prob_motion"].shape[0] > 0
+
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")


### PR DESCRIPTION
## Summary

- Implements `Instant4DAdapter` class for 4D Gaussian Splatting reconstruction via Instant4D
- Updates `GaussianTrainingStage` to use the new adapter instead of stubbed implementation
- Adds comprehensive unit tests for adapter functionality
- Updates documentation to reflect Step 2 completion

## Test plan

- [x] Run import tests: `python3 -c "from backend.adapters.instant4d import Instant4DAdapter, Instant4DOptions, Instant4DResult"`
- [x] Run CPU unit tests: `python3 -m pytest tests/adapters/test_instant4d_adapter.py -v -k "not gpu"`
- [ ] Run GPU tests on server: `pytest tests/adapters/test_instant4d_adapter.py -v -m gpu`
- [ ] End-to-end test with sample video (5-10 seconds)

## Files Changed

### New Files
- `backend/adapters/instant4d.py` (~850 lines) - Instant4DAdapter with preprocessing, training, and per-frame PLY export
- `tests/adapters/test_instant4d_adapter.py` (~500 lines) - Unit and integration tests
- `tests/adapters/__init__.py` - Package init

### Modified Files
- `backend/adapters/__init__.py` - Export Instant4DAdapter, Instant4DOptions, Instant4DResult
- `backend/stages/gaussian_training.py` - Delegate to Instant4DAdapter, add 4D result fields

## Key Implementation Details

**Instant4DAdapter Features:**
- Preprocessing: Converts Stage 1 output (Nerfstudio format) to Instant4D `filtered_cvd.npz`
- Stage 2 Integration: Uses SAM-2 masks to compute `prob_motion` for dynamic/static separation
- Grid Pruning: Voxel-based filtering achieving ~92% Gaussian reduction
- Training: 4D Gaussian optimization wrapper with progress reporting
- Export: Per-frame PLY extraction via temporal queries at arbitrary timestamps

**GaussianTrainingResult New Fields:**
- `ply_paths: List[str]` - Per-frame PLY files for 4D support
- `model_path: str` - 4D checkpoint path
- `num_frames: int` - Frame count
- `temporal_metadata: dict` - fps, duration, timestamps