### PR TITLE
feat: add mega-SAM pose estimation (phase 0, stage 3)

### DIFF
--- a/backend/adapters/instant4d.py
+++ b/backend/adapters/instant4d.py
@@ -257,11 +257,16 @@ class Instant4DAdapter:
         Converts Stage 1/2 outputs to Instant4D's filtered_cvd.npz format:
         - xyz: 3D point positions
         - rgb: Point colors
-        - prob_motion: Motion probability (from Stage 2 masks)
+        - prob_motion: Motion probability (from Stage 2 masks or Mega-SAM)
         - time_stamp: Temporal coordinate
         - scale_time: Temporal scale
         - intrinsic: Camera intrinsics
         - cam_c2w: Camera-to-world transforms
+
+        When Mega-SAM was used for pose estimation, the video_result metadata
+        may contain:
+        - depth_maps_dir: Path to dense depth maps (better initialization)
+        - motion_prob_path: Path to Mega-SAM's motion probability
 
         Args:
             video_result: Output from Stage 1 (frames + poses)
@@ -300,30 +305,51 @@ class Instant4DAdapter:
 
         # Step 4: Load or generate point cloud
         report(0.2, "Loading point cloud")
-        if video_result.sparse_points_path and Path(video_result.sparse_points_path).exists():
-            xyz, rgb = self._load_sparse_points(video_result.sparse_points_path)
-            report(0.3, f"Loaded {xyz.shape[0]} sparse points")
-        else:
-            xyz, rgb = self._generate_initial_points(
-                cam_c2w, intrinsic, num_frames, options.num_pts
-            )
-            report(0.3, f"Generated {xyz.shape[0]} initial points")
 
-        # Step 5: Compute motion probabilities from Stage 2 masks
+        # Check if Mega-SAM depth maps are available (preferred)
+        depth_maps_dir = video_result.metadata.get("depth_maps_dir")
+        if depth_maps_dir and Path(depth_maps_dir).exists():
+            try:
+                xyz, rgb = self._load_points_from_megasam_depth(
+                    depth_maps_dir, video_result.frames_dir, cam_c2w, intrinsic
+                )
+                report(0.3, f"Loaded {xyz.shape[0]} points from Mega-SAM depth")
+            except Exception as e:
+                logger.warning(f"Failed to load Mega-SAM depth: {e}, falling back to sparse")
+                xyz, rgb = self._load_or_generate_points(
+                    video_result, cam_c2w, intrinsic, num_frames, options
+                )
+                report(0.3, f"Loaded/generated {xyz.shape[0]} points (fallback)")
+        else:
+            xyz, rgb = self._load_or_generate_points(
+                video_result, cam_c2w, intrinsic, num_frames, options
+            )
+            report(0.3, f"Loaded/generated {xyz.shape[0]} points")
+
+        # Step 5: Compute motion probabilities
         report(0.4, "Computing motion probabilities")
-        if segmentation_result and segmentation_result.objects:
-            prob_motion = self._compute_motion_from_masks(
-                segmentation_result, xyz, frames, cam_c2w, intrinsic
+
+        # Check if Mega-SAM motion probability is available (preferred)
+        motion_prob_path = video_result.metadata.get("motion_prob_path")
+        if motion_prob_path and Path(motion_prob_path).exists():
+            try:
+                prob_motion = self._load_megasam_motion_prob(
+                    motion_prob_path, xyz, cam_c2w, intrinsic
+                )
+                num_dynamic = np.sum(prob_motion > options.motion_threshold)
+                report(0.5, f"Loaded Mega-SAM motion prob, {num_dynamic} dynamic points")
+            except Exception as e:
+                logger.warning(f"Failed to load Mega-SAM motion prob: {e}")
+                prob_motion = self._compute_motion_fallback(
+                    segmentation_result, xyz, frames, cam_c2w, intrinsic, options
+                )
+                report(0.5, "Motion probability computed (fallback)")
+        else:
+            prob_motion = self._compute_motion_fallback(
+                segmentation_result, xyz, frames, cam_c2w, intrinsic, options
             )
             num_dynamic = np.sum(prob_motion > options.motion_threshold)
-            report(0.5, f"Found {num_dynamic} dynamic points")
-        else:
-            # No segmentation - assume all static
-            prob_motion = np.zeros(xyz.shape[0], dtype=np.float32)
-            logger.warning(
-                "No segmentation data provided. Assuming all points are static."
-            )
-            report(0.5, "No segmentation data - assuming all static")
+            report(0.5, f"Motion probability computed, {num_dynamic} dynamic points")
 
         # Step 6: Assign timestamps to points
         report(0.55, "Assigning temporal coordinates")
@@ -855,6 +881,213 @@ class Instant4DAdapter:
         rgb = np.random.rand(num_pts, 3).astype(np.float32)
 
         return xyz.astype(np.float32), rgb
+
+    def _load_or_generate_points(
+        self,
+        video_result: "VideoProcessingResult",
+        cam_c2w: np.ndarray,
+        intrinsic: np.ndarray,
+        num_frames: int,
+        options: Instant4DOptions,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Load sparse points or generate initial points."""
+        if video_result.sparse_points_path and Path(video_result.sparse_points_path).exists():
+            return self._load_sparse_points(video_result.sparse_points_path)
+        else:
+            return self._generate_initial_points(
+                cam_c2w, intrinsic, num_frames, options.num_pts
+            )
+
+    def _load_points_from_megasam_depth(
+        self,
+        depth_maps_dir: str,
+        frames_dir: str,
+        cam_c2w: np.ndarray,
+        intrinsic: np.ndarray,
+        subsample_rate: int = 3,
+        max_points: int = 200_000,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Load point cloud from Mega-SAM depth maps via back-projection.
+
+        Args:
+            depth_maps_dir: Directory containing depth NPZ files
+            frames_dir: Directory containing frame images
+            cam_c2w: (N, 4, 4) camera-to-world matrices
+            intrinsic: (3, 3) camera intrinsic matrix
+            subsample_rate: Subsample every N-th frame to reduce points
+            max_points: Maximum points to return
+
+        Returns:
+            xyz: (M, 3) point coordinates
+            rgb: (M, 3) point colors [0-1]
+        """
+        import cv2
+        from glob import glob
+
+        # Find depth file
+        depth_files = sorted(glob(f"{depth_maps_dir}/*_droid.npz"))
+        if not depth_files:
+            raise FileNotFoundError(f"No Mega-SAM depth files in {depth_maps_dir}")
+
+        # Load the NPZ file
+        data = np.load(depth_files[0])
+        depths = data["depths"]  # (N, H, W)
+        images = data.get("images")  # (N, H, W, 3) or None
+
+        all_xyz = []
+        all_rgb = []
+
+        # Subsample frames
+        frame_indices = list(range(0, depths.shape[0], subsample_rate))
+
+        for idx in frame_indices:
+            depth = depths[idx]
+            H, W = depth.shape
+
+            # Create pixel grid
+            u, v = np.meshgrid(np.arange(W), np.arange(H))
+            u = u.flatten() + 0.5
+            v = v.flatten() + 0.5
+            z = depth.flatten()
+
+            # Filter valid depths
+            valid = (z > 0.01) & (z < 100.0) & np.isfinite(z)
+
+            # Subsample pixels
+            valid_indices = np.where(valid)[0]
+            if len(valid_indices) > max_points // len(frame_indices):
+                valid_indices = np.random.choice(
+                    valid_indices,
+                    max_points // len(frame_indices),
+                    replace=False
+                )
+
+            u, v, z = u[valid_indices], v[valid_indices], z[valid_indices]
+
+            # Back-project to camera space
+            fx, fy = intrinsic[0, 0], intrinsic[1, 1]
+            cx, cy = intrinsic[0, 2], intrinsic[1, 2]
+
+            x = (u - cx) * z / fx
+            y = (v - cy) * z / fy
+            xyz_cam = np.stack([x, y, z], axis=1)
+
+            # Transform to world coordinates
+            if idx < cam_c2w.shape[0]:
+                c2w = cam_c2w[idx]
+                xyz_world = (c2w[:3, :3] @ xyz_cam.T + c2w[:3, 3:4]).T
+                all_xyz.append(xyz_world)
+
+                # Get colors if available
+                if images is not None:
+                    img = images[idx]
+                    pixel_u = np.clip(u.astype(int), 0, W - 1)
+                    pixel_v = np.clip(v.astype(int), 0, H - 1)
+                    colors = img[pixel_v, pixel_u] / 255.0
+                    all_rgb.append(colors)
+                else:
+                    all_rgb.append(np.ones((xyz_world.shape[0], 3)) * 0.5)
+
+        xyz = np.concatenate(all_xyz, axis=0).astype(np.float32)
+        rgb = np.concatenate(all_rgb, axis=0).astype(np.float32)
+
+        # Final subsampling if too many points
+        if xyz.shape[0] > max_points:
+            indices = np.random.choice(xyz.shape[0], max_points, replace=False)
+            xyz = xyz[indices]
+            rgb = rgb[indices]
+
+        logger.info(f"Loaded {xyz.shape[0]} points from Mega-SAM depth")
+        return xyz, rgb
+
+    def _load_megasam_motion_prob(
+        self,
+        motion_prob_path: str,
+        xyz: np.ndarray,
+        cam_c2w: np.ndarray,
+        intrinsic: np.ndarray,
+    ) -> np.ndarray:
+        """
+        Load motion probability from Mega-SAM and interpolate to 3D points.
+
+        Mega-SAM provides per-pixel motion probability maps. We project 3D points
+        to the image and sample the motion probability.
+
+        Args:
+            motion_prob_path: Path to motion_prob.npy (N, H/8, W/8)
+            xyz: (M, 3) 3D point coordinates
+            cam_c2w: (N, 4, 4) camera-to-world matrices
+            intrinsic: (3, 3) camera intrinsics
+
+        Returns:
+            prob_motion: (M,) motion probability for each point
+        """
+        import cv2
+
+        motion_maps = np.load(motion_prob_path)  # (N, H/8, W/8)
+        num_points = xyz.shape[0]
+        motion_sum = np.zeros(num_points, dtype=np.float32)
+        visible_count = np.zeros(num_points, dtype=np.float32)
+
+        for frame_idx in range(min(motion_maps.shape[0], cam_c2w.shape[0])):
+            motion_map = motion_maps[frame_idx]  # (H/8, W/8)
+            h, w = motion_map.shape
+
+            # Get camera matrices
+            c2w = cam_c2w[frame_idx]
+            w2c = np.linalg.inv(c2w)
+
+            # Project 3D points to camera space
+            xyz_cam = (w2c[:3, :3] @ xyz.T + w2c[:3, 3:4]).T
+            z = xyz_cam[:, 2]
+            valid = z > 0.1
+
+            # Project to image (at 1/8 resolution)
+            uv = (intrinsic @ xyz_cam.T).T
+            uv = uv[:, :2] / (uv[:, 2:3] + 1e-8)
+            uv = uv / 8.0  # Scale to motion map resolution
+
+            # Sample motion probability
+            u = np.clip(uv[:, 0].astype(int), 0, w - 1)
+            v = np.clip(uv[:, 1].astype(int), 0, h - 1)
+
+            motion_values = motion_map[v, u]
+
+            # Accumulate for visible points
+            motion_sum[valid] += motion_values[valid]
+            visible_count[valid] += 1
+
+        # Average motion probability
+        prob_motion = np.zeros(num_points, dtype=np.float32)
+        has_observations = visible_count > 0
+        prob_motion[has_observations] = motion_sum[has_observations] / visible_count[has_observations]
+
+        logger.info(
+            f"Loaded Mega-SAM motion prob: "
+            f"{np.sum(prob_motion > 0.5)} dynamic, {np.sum(prob_motion <= 0.5)} static points"
+        )
+        return prob_motion
+
+    def _compute_motion_fallback(
+        self,
+        segmentation_result: Optional["ObjectSegmentationResult"],
+        xyz: np.ndarray,
+        frames: List[Dict[str, Any]],
+        cam_c2w: np.ndarray,
+        intrinsic: np.ndarray,
+        options: Instant4DOptions,
+    ) -> np.ndarray:
+        """Compute motion probability using SAM-2 masks or assume static."""
+        if segmentation_result and segmentation_result.objects:
+            return self._compute_motion_from_masks(
+                segmentation_result, xyz, frames, cam_c2w, intrinsic
+            )
+        else:
+            logger.warning(
+                "No segmentation or Mega-SAM motion data. Assuming all points static."
+            )
+            return np.zeros(xyz.shape[0], dtype=np.float32)
 
     def _compute_motion_from_masks(
         self,

--- a/backend/stages/video_processing.py
+++ b/backend/stages/video_processing.py
@@ -3,14 +3,785 @@
 import subprocess
 import json
 import logging
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Callable, Tuple
+from typing import Optional, Callable, Tuple, List
 
 import numpy as np
 
 # Setup logging
 logger = logging.getLogger(__name__)
+
+# Path to Mega-SAM submodule
+MEGASAM_PATH = Path(__file__).parent.parent.parent / "instant4d" / "SLAM" / "mega-sam"
+
+
+class MegaSamError(RuntimeError):
+    """Exception indicating Mega-SAM pipeline failed and should fall back to hloc."""
+    pass
+
+
+@dataclass
+class MegaSamResult:
+    """Result from Mega-SAM pose estimation pipeline."""
+
+    poses: np.ndarray
+    """Camera-to-world matrices (N, 4, 4)."""
+
+    intrinsics: np.ndarray
+    """Camera intrinsics matrix (3, 3)."""
+
+    depth_maps_dir: Optional[str] = None
+    """Directory containing per-frame depth NPZ files."""
+
+    motion_prob_path: Optional[str] = None
+    """Path to motion probability NPY file."""
+
+    num_keyframes: int = 0
+    """Number of keyframes tracked by DROID SLAM."""
+
+    metrics: dict = field(default_factory=dict)
+    """Quality metrics for validation."""
+
+
+class MegaSamPoseEstimator:
+    """
+    Mega-SAM pose estimation pipeline wrapper.
+
+    Mega-SAM is a SLAM-based camera tracking system that produces:
+    1. Camera poses (SE3 format, converted to 4x4 c2w matrices)
+    2. Dense depth maps per frame
+    3. Camera intrinsics from UniDepth FOV estimation
+    4. Motion probability masks (dynamic/static regions)
+
+    The pipeline consists of:
+    1. UniDepth - Metric depth + FOV estimation per frame
+    2. Depth-Anything - Mono disparity estimation
+    3. Depth Alignment - Scale/shift calibration between depths
+    4. DROID SLAM - Camera tracking with bundle adjustment
+    5. Post-processing - SE3 to 4x4, coordinate convention conversion
+
+    Output format is compatible with Instant4D's filtered_cvd.npz.
+    """
+
+    # Required checkpoints
+    DROID_WEIGHTS = MEGASAM_PATH / "checkpoints" / "megasam_final.pth"
+    DEPTH_ANYTHING_WEIGHTS = MEGASAM_PATH / "Depth-Anything" / "checkpoints" / "depth_anything_vitl14.pth"
+
+    def __init__(self, config: dict = None):
+        """
+        Initialize Mega-SAM pose estimator.
+
+        Args:
+            config: Configuration dict with optional keys:
+                - opt_focal: Whether to optimize focal length (default: True)
+                - max_frames: Max frames before subsampling (default: 300)
+                - disable_vis: Disable DROID visualization (default: True)
+        """
+        self.config = config or {}
+        self.opt_focal = self.config.get("opt_focal", True)
+        self.max_frames = self.config.get("max_frames", 300)
+        self.disable_vis = self.config.get("disable_vis", True)
+        self._path_added = False
+        self._available = None
+
+    def is_available(self) -> bool:
+        """
+        Check if Mega-SAM dependencies are available.
+
+        Returns:
+            True if all checkpoints and imports are available.
+        """
+        if self._available is not None:
+            return self._available
+
+        # Check checkpoints exist
+        if not self.DROID_WEIGHTS.exists():
+            logger.warning(
+                f"Mega-SAM DROID weights not found: {self.DROID_WEIGHTS}\n"
+                "Run: bash scripts/setup_megasam.sh"
+            )
+            self._available = False
+            return False
+
+        # Check if lietorch can be imported (requires CUDA compilation)
+        try:
+            self._add_megasam_to_path()
+            import lietorch  # noqa: F401
+            self._available = True
+        except ImportError as e:
+            logger.warning(
+                f"lietorch not available: {e}\n"
+                "Mega-SAM requires CUDA-compiled lietorch.\n"
+                "Run: cd instant4d/SLAM/mega-sam/base && python setup.py install"
+            )
+            self._available = False
+
+        return self._available
+
+    def _add_megasam_to_path(self):
+        """Add Mega-SAM directories to Python path."""
+        if self._path_added:
+            return
+
+        paths_to_add = [
+            str(MEGASAM_PATH / "base" / "droid_slam"),
+            str(MEGASAM_PATH / "base"),
+            str(MEGASAM_PATH),
+        ]
+
+        for path in paths_to_add:
+            if path not in sys.path:
+                sys.path.insert(0, path)
+
+        self._path_added = True
+
+    def estimate_poses(
+        self,
+        frames_dir: Path,
+        output_dir: Path,
+        progress_callback: Optional[Callable[[float, str], None]] = None,
+    ) -> MegaSamResult:
+        """
+        Run full Mega-SAM pipeline for pose estimation.
+
+        Args:
+            frames_dir: Directory containing extracted frames (*.jpg)
+            output_dir: Working directory for intermediate outputs
+            progress_callback: Optional callback(progress, message)
+
+        Returns:
+            MegaSamResult with poses, intrinsics, depth, motion probability
+
+        Raises:
+            MegaSamError: If pipeline fails (caller should fall back to hloc)
+        """
+        import torch
+        import cv2
+
+        def report(pct: float, msg: str):
+            logger.info(f"[Mega-SAM {pct:.0%}] {msg}")
+            if progress_callback:
+                progress_callback(pct, msg)
+
+        if not self.is_available():
+            raise MegaSamError("Mega-SAM dependencies not available")
+
+        self._add_megasam_to_path()
+
+        # Get list of frames
+        image_list = sorted(list(frames_dir.glob("*.jpg")) + list(frames_dir.glob("*.png")))
+        if not image_list:
+            raise MegaSamError(f"No images found in {frames_dir}")
+
+        num_frames = len(image_list)
+        logger.info(f"Processing {num_frames} frames with Mega-SAM")
+
+        # Subsample if too many frames
+        if num_frames > self.max_frames:
+            subsample_rate = num_frames // self.max_frames + 1
+            image_list = image_list[::subsample_rate]
+            logger.info(f"Subsampled to {len(image_list)} frames (rate: 1/{subsample_rate})")
+
+        # Create output directories
+        unidepth_dir = output_dir / "megasam" / "unidepth"
+        depth_anything_dir = output_dir / "megasam" / "depth_anything"
+        reconstructions_dir = output_dir / "megasam" / "reconstructions"
+        outputs_dir = output_dir / "megasam" / "outputs"
+
+        for d in [unidepth_dir, depth_anything_dir, reconstructions_dir, outputs_dir]:
+            d.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # Step 1: Run UniDepth for metric depth + FOV
+            report(0.0, "Running UniDepth for metric depth estimation")
+            fovs = self._run_unidepth(image_list, unidepth_dir)
+            report(0.2, f"UniDepth complete, median FOV: {np.median(fovs):.1f}°")
+
+            # Step 2: Run Depth-Anything for mono disparity
+            report(0.2, "Running Depth-Anything for mono disparity")
+            self._run_depth_anything(image_list, depth_anything_dir)
+            report(0.4, "Depth-Anything complete")
+
+            # Step 3: Align depths and compute intrinsics
+            report(0.4, "Aligning depth estimates")
+            aligns, intrinsics_K = self._align_depths(
+                image_list, unidepth_dir, depth_anything_dir
+            )
+            report(0.5, "Depth alignment complete")
+
+            # Step 4: Run DROID SLAM
+            report(0.5, "Running DROID SLAM camera tracking")
+            poses_se3, depth_est, motion_prob, num_keyframes = self._run_droid_slam(
+                image_list, unidepth_dir, depth_anything_dir, aligns, intrinsics_K,
+                reconstructions_dir
+            )
+            report(0.85, f"DROID SLAM complete, {num_keyframes} keyframes")
+
+            # Step 5: Convert SE3 to c2w matrices
+            report(0.85, "Converting poses to camera-to-world matrices")
+            cam_c2w = self._se3_to_c2w(poses_se3)
+
+            # Step 6: Save outputs
+            report(0.9, "Saving outputs")
+            scene_name = "scene"
+
+            # Save motion probability
+            motion_prob_path = reconstructions_dir / "motion_prob.npy"
+            np.save(motion_prob_path, motion_prob)
+
+            # Save depth maps
+            depth_output_path = outputs_dir / f"{scene_name}_droid.npz"
+            img_0 = cv2.imread(str(image_list[0]))
+            np.savez(
+                depth_output_path,
+                images=np.zeros((len(image_list), img_0.shape[0], img_0.shape[1], 3), dtype=np.uint8),  # Placeholder
+                depths=depth_est,
+                intrinsic=intrinsics_K,
+                cam_c2w=cam_c2w,
+            )
+
+            report(1.0, "Mega-SAM pipeline complete")
+
+            return MegaSamResult(
+                poses=cam_c2w,
+                intrinsics=intrinsics_K,
+                depth_maps_dir=str(outputs_dir),
+                motion_prob_path=str(motion_prob_path),
+                num_keyframes=num_keyframes,
+                metrics={
+                    "num_frames": len(image_list),
+                    "median_fov": float(np.median(fovs)),
+                }
+            )
+
+        except Exception as e:
+            logger.error(f"Mega-SAM pipeline failed: {e}")
+            raise MegaSamError(f"Mega-SAM pipeline failed: {e}") from e
+        finally:
+            # Cleanup GPU memory
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    def _run_unidepth(self, image_list: List[Path], output_dir: Path) -> List[float]:
+        """
+        Run UniDepth for metric depth and FOV estimation.
+
+        Args:
+            image_list: List of image paths
+            output_dir: Directory to save depth NPZ files
+
+        Returns:
+            List of FOV estimates per frame
+        """
+        import torch
+        import cv2
+
+        try:
+            # UniDepth auto-downloads from HuggingFace
+            from unidepth.models import UniDepthV2
+        except ImportError:
+            raise MegaSamError(
+                "UniDepth not installed. Install with: pip install unidepth"
+            )
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model = UniDepthV2.from_pretrained("lpiccinelli/unidepth-v2-vitl14")
+        model = model.to(device).eval()
+
+        fovs = []
+
+        try:
+            with torch.no_grad():
+                for i, img_path in enumerate(image_list):
+                    # Load and preprocess image
+                    image = cv2.imread(str(img_path))
+                    image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
+                    # Run inference
+                    predictions = model.infer(image_rgb)
+
+                    depth = predictions["depth"].cpu().numpy().squeeze()
+                    fov = predictions.get("fov", torch.tensor([60.0])).cpu().numpy().item()
+
+                    fovs.append(fov)
+
+                    # Save output
+                    output_path = output_dir / f"frame_{i:05d}.npz"
+                    np.savez(output_path, depth=depth, fov=fov)
+
+                    if (i + 1) % 10 == 0:
+                        logger.debug(f"UniDepth: processed {i + 1}/{len(image_list)} frames")
+
+        finally:
+            del model
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+        return fovs
+
+    def _run_depth_anything(self, image_list: List[Path], output_dir: Path):
+        """
+        Run Depth-Anything for mono disparity estimation.
+
+        Args:
+            image_list: List of image paths
+            output_dir: Directory to save disparity NPY files
+        """
+        import torch
+        import cv2
+
+        # Check if checkpoint exists
+        if not self.DEPTH_ANYTHING_WEIGHTS.exists():
+            raise MegaSamError(
+                f"Depth-Anything weights not found: {self.DEPTH_ANYTHING_WEIGHTS}\n"
+                "Download from: https://huggingface.co/spaces/LiheYoung/Depth-Anything"
+            )
+
+        try:
+            # Add Depth-Anything to path
+            da_path = MEGASAM_PATH / "Depth-Anything"
+            if str(da_path) not in sys.path:
+                sys.path.insert(0, str(da_path))
+
+            from depth_anything.dpt import DepthAnything
+            from depth_anything.util.transform import Resize, NormalizeImage, PrepareForNet
+            from torchvision.transforms import Compose
+        except ImportError:
+            raise MegaSamError(
+                "Depth-Anything dependencies not available. Check installation."
+            )
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        # Load model
+        model = DepthAnything.from_pretrained(
+            "LiheYoung/depth-anything-large-hf"
+        ).to(device).eval()
+
+        # Setup transforms
+        transform = Compose([
+            Resize(
+                width=518,
+                height=518,
+                resize_target=False,
+                keep_aspect_ratio=True,
+                ensure_multiple_of=14,
+                resize_method='lower_bound',
+                image_interpolation_method=cv2.INTER_CUBIC,
+            ),
+            NormalizeImage(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            PrepareForNet(),
+        ])
+
+        try:
+            with torch.no_grad():
+                for i, img_path in enumerate(image_list):
+                    # Load image
+                    image = cv2.imread(str(img_path))
+                    image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB) / 255.0
+
+                    # Transform
+                    h, w = image.shape[:2]
+                    image_tensor = transform({'image': image_rgb})['image']
+                    image_tensor = torch.from_numpy(image_tensor).unsqueeze(0).to(device)
+
+                    # Inference
+                    depth = model(image_tensor)
+                    depth = torch.nn.functional.interpolate(
+                        depth.unsqueeze(1),
+                        size=(h, w),
+                        mode='bicubic',
+                        align_corners=False
+                    ).squeeze().cpu().numpy()
+
+                    # Depth-Anything outputs disparity (inverse depth)
+                    disp = depth
+
+                    # Save
+                    output_path = output_dir / f"frame_{i:05d}.npy"
+                    np.save(output_path, disp.astype(np.float32))
+
+                    if (i + 1) % 10 == 0:
+                        logger.debug(f"Depth-Anything: processed {i + 1}/{len(image_list)} frames")
+
+        finally:
+            del model
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    def _align_depths(
+        self,
+        image_list: List[Path],
+        unidepth_dir: Path,
+        depth_anything_dir: Path,
+    ) -> Tuple[Tuple[float, float, float], np.ndarray]:
+        """
+        Align mono disparity with metric depth using scale/shift calibration.
+
+        Follows Mega-SAM's alignment strategy from test_demo.py:
+        - Handles sky regions specially (when sky_ratio > 0.5)
+        - Uses median-based scale/shift estimation
+
+        Args:
+            image_list: List of image paths
+            unidepth_dir: Directory with UniDepth outputs
+            depth_anything_dir: Directory with Depth-Anything outputs
+
+        Returns:
+            Tuple of:
+                - aligns: (scale, shift, normalize_scale)
+                - intrinsics_K: 3x3 camera intrinsic matrix
+        """
+        import cv2
+
+        # Load first image for dimensions
+        img_0 = cv2.imread(str(image_list[0]))
+        h, w = img_0.shape[:2]
+
+        scales = []
+        shifts = []
+        fovs = []
+        mono_disps = []
+
+        for i in range(len(image_list)):
+            # Load UniDepth output
+            unidepth_path = unidepth_dir / f"frame_{i:05d}.npz"
+            uni_data = np.load(unidepth_path)
+            metric_depth = uni_data["depth"]
+            fovs.append(uni_data["fov"])
+
+            # Load Depth-Anything disparity
+            da_path = depth_anything_dir / f"frame_{i:05d}.npy"
+            da_disp = np.float32(np.load(da_path))
+
+            # Resize disparity to match metric depth
+            da_disp = cv2.resize(
+                da_disp,
+                (metric_depth.shape[1], metric_depth.shape[0]),
+                interpolation=cv2.INTER_NEAREST_EXACT,
+            )
+            mono_disps.append(da_disp)
+
+            # Convert metric depth to disparity
+            gt_disp = 1.0 / (metric_depth + 1e-8)
+
+            # Handle UniDepth bugs
+            valid_mask = (metric_depth < 2.0) & (da_disp < 0.02)
+            gt_disp[valid_mask] = 1e-2
+
+            # Compute scale/shift with sky handling
+            sky_ratio = np.sum(da_disp < 0.01) / (da_disp.shape[0] * da_disp.shape[1])
+
+            if sky_ratio > 0.5:
+                # Sky-dominated: use non-sky regions only
+                non_sky_mask = da_disp > 0.01
+                gt_disp_ms = gt_disp[non_sky_mask] - np.median(gt_disp[non_sky_mask]) + 1e-8
+                da_disp_ms = da_disp[non_sky_mask] - np.median(da_disp[non_sky_mask]) + 1e-8
+                scale = np.median(gt_disp_ms / da_disp_ms)
+                shift = np.median(gt_disp[non_sky_mask] - scale * da_disp[non_sky_mask])
+            else:
+                gt_disp_ms = gt_disp - np.median(gt_disp) + 1e-8
+                da_disp_ms = da_disp - np.median(da_disp) + 1e-8
+                scale = np.median(gt_disp_ms / da_disp_ms)
+                shift = np.median(gt_disp - scale * da_disp)
+
+            scales.append(scale)
+            shifts.append(shift)
+
+        # Find median scale/shift
+        ss_product = np.array(scales) * np.array(shifts)
+        med_idx = np.argmin(np.abs(ss_product - np.median(ss_product)))
+
+        align_scale = scales[med_idx]
+        align_shift = shifts[med_idx]
+        normalize_scale = np.percentile(
+            align_scale * np.array(mono_disps[med_idx]) + align_shift, 98
+        ) / 2.0
+
+        aligns = (align_scale, align_shift, normalize_scale)
+
+        # Compute intrinsics from median FOV
+        median_fov = np.median(fovs)
+        focal_length = w / (2 * np.tan(np.radians(median_fov) / 2.0))
+
+        K = np.eye(3, dtype=np.float32)
+        K[0, 0] = focal_length
+        K[1, 1] = focal_length
+        K[0, 2] = w / 2.0
+        K[1, 2] = h / 2.0
+
+        logger.info(f"Depth alignment: scale={align_scale:.4f}, shift={align_shift:.4f}")
+        logger.info(f"Intrinsics from FOV {median_fov:.1f}°: fx=fy={focal_length:.1f}")
+
+        return aligns, K
+
+    def _run_droid_slam(
+        self,
+        image_list: List[Path],
+        unidepth_dir: Path,
+        depth_anything_dir: Path,
+        aligns: Tuple[float, float, float],
+        intrinsics_K: np.ndarray,
+        reconstructions_dir: Path,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+        """
+        Run DROID SLAM for camera tracking.
+
+        Args:
+            image_list: List of image paths
+            unidepth_dir: Directory with UniDepth outputs
+            depth_anything_dir: Directory with Depth-Anything outputs
+            aligns: (scale, shift, normalize_scale) from depth alignment
+            intrinsics_K: 3x3 camera intrinsic matrix
+            reconstructions_dir: Directory for SLAM outputs
+
+        Returns:
+            Tuple of:
+                - poses_se3: (N, 7) SE3 poses [x, y, z, qx, qy, qz, qw]
+                - depth_est: (N, H, W) estimated depths
+                - motion_prob: (N, H/8, W/8) motion probability
+                - num_keyframes: Number of keyframes
+        """
+        import torch
+        import cv2
+        from argparse import Namespace
+
+        # Import DROID components
+        self._add_megasam_to_path()
+        from droid import Droid
+
+        align_scale, align_shift, normalize_scale = aligns
+
+        # Setup DROID arguments
+        args = Namespace(
+            weights=str(self.DROID_WEIGHTS),
+            buffer=1024,
+            image_size=[240, 320],  # Will be updated from first frame
+            disable_vis=self.disable_vis,
+            beta=0.3,
+            filter_thresh=2.0,
+            warmup=8,
+            keyframe_thresh=2.0,
+            frontend_thresh=12.0,
+            frontend_window=25,
+            frontend_radius=2,
+            frontend_nms=1,
+            stereo=False,
+            depth=True,
+            upsample=False,
+            backend_thresh=16.0,
+            backend_radius=2,
+            backend_nms=3,
+        )
+
+        # Initialize storage
+        rgb_list = []
+        sensor_depth_list = []
+        droid = None
+
+        try:
+            for t, img_path in enumerate(image_list):
+                # Load image
+                image = cv2.imread(str(img_path))
+                h0, w0 = image.shape[:2]
+
+                # Resize to ~384x512 area
+                h1 = int(h0 * np.sqrt((384 * 512) / (h0 * w0)))
+                w1 = int(w0 * np.sqrt((384 * 512) / (h0 * w0)))
+                image = cv2.resize(image, (w1, h1), interpolation=cv2.INTER_AREA)
+                image = image[: h1 - h1 % 8, : w1 - w1 % 8]
+
+                # Load mono disparity
+                da_path = depth_anything_dir / f"frame_{t:05d}.npy"
+                mono_disp = np.float32(np.load(da_path))
+
+                # Align to metric depth
+                depth = np.clip(
+                    1.0 / ((1.0 / normalize_scale) * (align_scale * mono_disp + align_shift)),
+                    1e-4,
+                    1e4,
+                )
+                depth[depth < 1e-2] = 0.0
+
+                # Convert to tensors
+                image_tensor = torch.as_tensor(image).permute(2, 0, 1)
+                depth_tensor = torch.as_tensor(depth)
+                depth_tensor = torch.nn.functional.interpolate(
+                    depth_tensor[None, None], (h1, w1), mode="nearest-exact"
+                ).squeeze()
+                depth_tensor = depth_tensor[: h1 - h1 % 8, : w1 - w1 % 8]
+
+                mask = torch.ones_like(depth_tensor)
+
+                # Scale intrinsics for resized image
+                intrinsics = torch.as_tensor([
+                    intrinsics_K[0, 0], intrinsics_K[1, 1],
+                    intrinsics_K[0, 2], intrinsics_K[1, 2]
+                ])
+                intrinsics[0::2] *= w1 / w0
+                intrinsics[1::2] *= h1 / h0
+
+                # Initialize DROID on first frame
+                if t == 0:
+                    args.image_size = [image_tensor.shape[1], image_tensor.shape[2]]
+                    droid = Droid(args)
+
+                rgb_list.append(image_tensor[None])
+                sensor_depth_list.append(depth_tensor)
+
+                # Track frame
+                if t < len(image_list) - 1:
+                    droid.track(t, image_tensor[None], depth_tensor, intrinsics=intrinsics, mask=mask)
+                else:
+                    droid.track_final(t, image_tensor[None], depth_tensor, intrinsics=intrinsics, mask=mask)
+
+            # Terminate and get final poses
+            traj_est, depth_est, motion_prob = droid.terminate(
+                stream=self._make_image_stream(
+                    image_list, depth_anything_dir, aligns, intrinsics_K
+                ),
+                _opt_intr=self.opt_focal,
+                full_ba=True,
+                scene_name="scene",
+            )
+
+            num_keyframes = droid.video.counter.value
+
+            return traj_est, depth_est, motion_prob, num_keyframes
+
+        finally:
+            if droid is not None:
+                del droid
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    def _make_image_stream(
+        self,
+        image_list: List[Path],
+        depth_anything_dir: Path,
+        aligns: Tuple[float, float, float],
+        intrinsics_K: np.ndarray,
+    ):
+        """Generator for DROID's terminate() stream parameter."""
+        import torch
+        import cv2
+
+        align_scale, align_shift, normalize_scale = aligns
+
+        for t, img_path in enumerate(image_list):
+            image = cv2.imread(str(img_path))
+            h0, w0 = image.shape[:2]
+
+            h1 = int(h0 * np.sqrt((384 * 512) / (h0 * w0)))
+            w1 = int(w0 * np.sqrt((384 * 512) / (h0 * w0)))
+            image = cv2.resize(image, (w1, h1), interpolation=cv2.INTER_AREA)
+            image = image[: h1 - h1 % 8, : w1 - w1 % 8]
+
+            da_path = depth_anything_dir / f"frame_{t:05d}.npy"
+            mono_disp = np.float32(np.load(da_path))
+
+            depth = np.clip(
+                1.0 / ((1.0 / normalize_scale) * (align_scale * mono_disp + align_shift)),
+                1e-4,
+                1e4,
+            )
+            depth[depth < 1e-2] = 0.0
+
+            image_tensor = torch.as_tensor(image).permute(2, 0, 1)
+            depth_tensor = torch.as_tensor(depth)
+            depth_tensor = torch.nn.functional.interpolate(
+                depth_tensor[None, None], (h1, w1), mode="nearest-exact"
+            ).squeeze()
+            depth_tensor = depth_tensor[: h1 - h1 % 8, : w1 - w1 % 8]
+
+            mask = torch.ones_like(depth_tensor)
+
+            intrinsics = torch.as_tensor([
+                intrinsics_K[0, 0], intrinsics_K[1, 1],
+                intrinsics_K[0, 2], intrinsics_K[1, 2]
+            ])
+            intrinsics[0::2] *= w1 / w0
+            intrinsics[1::2] *= h1 / h0
+
+            yield t, image_tensor[None], depth_tensor, intrinsics, mask
+
+    def _se3_to_c2w(self, poses_se3: np.ndarray) -> np.ndarray:
+        """
+        Convert SE3 poses to 4x4 camera-to-world matrices.
+
+        DROID stores poses as SE3: [x, y, z, qx, qy, qz, qw] (7D)
+        We convert using lietorch: SE3(poses).inv().matrix()
+
+        Args:
+            poses_se3: (N, 7) SE3 poses
+
+        Returns:
+            cam_c2w: (N, 4, 4) camera-to-world matrices
+        """
+        import torch
+        from lietorch import SE3
+
+        poses_th = torch.as_tensor(poses_se3, device="cpu")
+        cam_c2w = SE3(poses_th).inv().matrix().numpy()
+
+        return cam_c2w
+
+    def to_transforms_json(
+        self,
+        result: MegaSamResult,
+        frame_paths: List[Path],
+        output_path: Path,
+        image_size: Tuple[int, int],
+    ):
+        """
+        Export Mega-SAM result to Nerfstudio transforms.json format.
+
+        Converts from COLMAP/Mega-SAM convention to OpenGL convention
+        by flipping Y and Z columns.
+
+        Args:
+            result: MegaSamResult from estimate_poses()
+            frame_paths: List of frame paths
+            output_path: Path to save transforms.json
+            image_size: (width, height) of original images
+        """
+        width, height = image_size
+        K = result.intrinsics
+
+        # Convert to OpenGL convention (flip Y and Z)
+        cam_c2w = result.poses.copy()
+        for i in range(cam_c2w.shape[0]):
+            cam_c2w[i, :3, 1:3] *= -1
+
+        transforms = {
+            "camera_model": "OPENCV",
+            "fl_x": float(K[0, 0]),
+            "fl_y": float(K[1, 1]),
+            "cx": float(K[0, 2]),
+            "cy": float(K[1, 2]),
+            "w": width,
+            "h": height,
+            "k1": 0.0,
+            "k2": 0.0,
+            "p1": 0.0,
+            "p2": 0.0,
+            "frames": []
+        }
+
+        for i, frame_path in enumerate(frame_paths):
+            if i < len(cam_c2w):
+                frame = {
+                    "file_path": f"./frames/{frame_path.name}",
+                    "transform_matrix": cam_c2w[i].tolist()
+                }
+                transforms["frames"].append(frame)
+
+        with open(output_path, 'w') as f:
+            json.dump(transforms, f, indent=2)
+
+        logger.info(f"Exported {len(transforms['frames'])} poses to {output_path}")
 
 
 @dataclass
@@ -39,17 +810,29 @@ class VideoProcessingStage:
 
     This stage:
     1. Extracts frames from input video using ffmpeg
-    2. Runs camera pose estimation (hloc + GLOMAP or DUSt3R fallback)
-    3. Generates sparse point cloud via COLMAP SfM
+    2. Runs camera pose estimation with cascading fallback:
+       - megasam (primary) -> hloc/GLOMAP -> DUSt3R
+    3. Generates sparse point cloud via COLMAP SfM (or dense from Mega-SAM)
 
-    Output: frames/, transforms.json, sparse/points3D.ply
+    Output: frames/, transforms.json, sparse/points3D.ply (or megasam/ outputs)
     """
 
     def __init__(self, config: dict = None):
         self.config = config or {}
-        self.pose_estimator = self.config.get("pose_estimator", "hloc")
+        # Default to megasam for Instant4D compatibility
+        self.pose_estimator = self.config.get("pose_estimator", "megasam")
         self.frame_interval = self.config.get("frame_interval", 1)  # Extract every Nth frame
         self.max_frames = self.config.get("max_frames", 300)
+
+        # Mega-SAM specific configuration
+        self.megasam_config = {
+            "opt_focal": self.config.get("megasam_opt_focal", True),
+            "max_frames": self.config.get("megasam_max_frames", 300),
+            "disable_vis": True,
+        }
+
+        # Initialize Mega-SAM estimator (lazy loaded)
+        self._megasam_estimator = None
 
     def process(
         self,
@@ -89,7 +872,39 @@ class VideoProcessingStage:
         transforms_path = output_path / "transforms.json"
         sparse_path = output_path / "sparse"
 
-        if self.pose_estimator == "hloc":
+        # Store Mega-SAM outputs for later inclusion in metadata
+        megasam_outputs = {}
+
+        if self.pose_estimator == "megasam":
+            try:
+                megasam_result = self._run_megasam_pipeline(
+                    frames_dir, output_path, transforms_path,
+                    lambda p, m: report(0.3 + p * 0.6, m)  # Scale progress 0.3-0.9
+                )
+                report(0.9, "Mega-SAM pipeline completed")
+
+                # Store Mega-SAM outputs for downstream stages
+                megasam_outputs = {
+                    "depth_maps_dir": megasam_result.depth_maps_dir,
+                    "motion_prob_path": megasam_result.motion_prob_path,
+                    "megasam_metrics": megasam_result.metrics,
+                }
+
+            except MegaSamError as e:
+                # Cascade fallback to hloc
+                logger.warning(f"Mega-SAM pipeline failed: {e}")
+                report(0.5, "Falling back to hloc/GLOMAP...")
+                try:
+                    self._run_hloc_pipeline(frames_dir, transforms_path, sparse_path)
+                    report(0.9, "hloc pipeline completed (fallback)")
+                except RuntimeError as e2:
+                    # Further cascade to DUSt3R
+                    logger.warning(f"hloc pipeline also failed: {e2}")
+                    report(0.7, "Falling back to DUSt3R...")
+                    self._run_dust3r_pipeline(frames_dir, transforms_path)
+                    report(0.9, "DUSt3R fallback completed")
+
+        elif self.pose_estimator == "hloc":
             try:
                 self._run_hloc_pipeline(frames_dir, transforms_path, sparse_path)
                 report(0.9, "hloc pipeline completed")
@@ -99,9 +914,11 @@ class VideoProcessingStage:
                 report(0.5, "Falling back to DUSt3R...")
                 self._run_dust3r_pipeline(frames_dir, transforms_path)
                 report(0.9, "DUSt3R fallback completed")
+
         elif self.pose_estimator == "dust3r":
             self._run_dust3r_pipeline(frames_dir, transforms_path)
             report(0.9, "DUSt3R pipeline completed")
+
         else:
             raise ValueError(f"Unknown pose estimator: {self.pose_estimator}")
 
@@ -114,6 +931,10 @@ class VideoProcessingStage:
         }
         if hasattr(self, "_video_metadata"):
             metadata.update(self._video_metadata)
+
+        # Include Mega-SAM outputs if available
+        if megasam_outputs:
+            metadata.update(megasam_outputs)
 
         # Check if sparse point cloud file exists (not just the directory)
         sparse_ply_path = sparse_path / "points3D.ply"
@@ -216,6 +1037,112 @@ class VideoProcessingStage:
 
         self._video_metadata["extracted_frames"] = num_frames
         return num_frames
+
+    def _get_megasam_estimator(self) -> MegaSamPoseEstimator:
+        """Get or create Mega-SAM pose estimator (lazy initialization)."""
+        if self._megasam_estimator is None:
+            self._megasam_estimator = MegaSamPoseEstimator(self.megasam_config)
+        return self._megasam_estimator
+
+    def _run_megasam_pipeline(
+        self,
+        frames_dir: Path,
+        output_dir: Path,
+        transforms_path: Path,
+        progress_callback: Optional[Callable[[float, str], None]] = None,
+    ) -> MegaSamResult:
+        """
+        Run Mega-SAM pipeline for pose estimation.
+
+        Mega-SAM is the preferred pose estimator for Instant4D as it provides:
+        - Camera poses via DROID SLAM
+        - Dense depth maps per frame
+        - Motion probability masks for dynamic/static separation
+
+        Pipeline:
+        1. UniDepth for metric depth + FOV estimation
+        2. Depth-Anything for mono disparity
+        3. Depth alignment (scale/shift calibration)
+        4. DROID SLAM for camera tracking
+        5. Export to transforms.json
+
+        Args:
+            frames_dir: Directory containing extracted frames
+            output_dir: Working directory for outputs
+            transforms_path: Path to save transforms.json
+            progress_callback: Optional callback(progress, message)
+
+        Returns:
+            MegaSamResult with poses, depth, motion probability
+
+        Raises:
+            MegaSamError: If pipeline fails (caller should fall back to hloc)
+        """
+        estimator = self._get_megasam_estimator()
+
+        # Check availability before running
+        if not estimator.is_available():
+            raise MegaSamError(
+                "Mega-SAM dependencies not available. "
+                "Ensure lietorch is compiled and checkpoints are downloaded. "
+                "Run: bash scripts/setup_megasam.sh"
+            )
+
+        # Run pose estimation
+        result = estimator.estimate_poses(
+            frames_dir=frames_dir,
+            output_dir=output_dir,
+            progress_callback=progress_callback,
+        )
+
+        # Validate result quality
+        self._validate_megasam_result(result, len(list(frames_dir.glob("*.jpg"))))
+
+        # Export to transforms.json
+        frame_paths = sorted(list(frames_dir.glob("*.jpg")) + list(frames_dir.glob("*.png")))
+        image_size = (self._video_metadata["width"], self._video_metadata["height"])
+        estimator.to_transforms_json(result, frame_paths, transforms_path, image_size)
+
+        logger.info(
+            f"Mega-SAM completed: {result.num_keyframes} keyframes, "
+            f"FOV={result.metrics.get('median_fov', 0):.1f}°"
+        )
+
+        return result
+
+    def _validate_megasam_result(self, result: MegaSamResult, total_frames: int):
+        """
+        Validate Mega-SAM output quality, raise MegaSamError if insufficient.
+
+        Validation criteria:
+        - Keyframe count >= 50% of input frames
+        - Poses are finite (no NaN/Inf)
+        - Intrinsics are reasonable (100 < focal < 5000)
+        """
+        # Criterion 1: Sufficient keyframes
+        if result.num_keyframes < total_frames * 0.5:
+            raise MegaSamError(
+                f"Too few keyframes: {result.num_keyframes}/{total_frames} "
+                f"({result.num_keyframes/total_frames:.0%} < 50%)"
+            )
+
+        # Criterion 2: Valid poses
+        if not np.isfinite(result.poses).all():
+            raise MegaSamError("Invalid poses (NaN/Inf detected)")
+
+        # Criterion 3: Reasonable intrinsics
+        fx = result.intrinsics[0, 0]
+        fy = result.intrinsics[1, 1]
+        if fx < 100 or fy < 100 or fx > 5000 or fy > 5000:
+            raise MegaSamError(
+                f"Unreasonable focal length: fx={fx:.1f}, fy={fy:.1f} "
+                "(expected 100-5000)"
+            )
+
+        logger.info(
+            f"Mega-SAM validation passed: {result.num_keyframes} keyframes, "
+            f"fx={fx:.1f}, fy={fy:.1f}"
+        )
 
     def _run_hloc_pipeline(self, frames_dir: Path, transforms_path: Path, sparse_path: Path):
         """

--- a/scripts/setup_megasam.sh
+++ b/scripts/setup_megasam.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+# =============================================================================
+# Mega-SAM Setup Script
+# =============================================================================
+#
+# This script sets up the Mega-SAM dependencies for Brain Dance's pose estimation.
+#
+# What it does:
+# 1. Verifies prerequisites (CUDA, PyTorch)
+# 2. Downloads required checkpoints (Depth-Anything, RAFT)
+# 3. Compiles CUDA extensions (lietorch, DROID SLAM)
+#
+# Requirements:
+# - CUDA 11.8+ toolkit installed
+# - PyTorch 2.0+ with CUDA support
+# - Git LFS for large checkpoint files
+#
+# Usage:
+#   bash scripts/setup_megasam.sh
+#
+# =============================================================================
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+MEGASAM_DIR="$PROJECT_ROOT/instant4d/SLAM/mega-sam"
+DEPTH_ANYTHING_DIR="$MEGASAM_DIR/Depth-Anything"
+CVD_OPT_DIR="$MEGASAM_DIR/cvd_opt"
+
+echo "=========================================="
+echo "Mega-SAM Setup for Brain Dance"
+echo "=========================================="
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 1: Verify Prerequisites
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}Step 1: Verifying prerequisites...${NC}"
+
+# Check CUDA
+if ! command -v nvcc &> /dev/null; then
+    echo -e "${RED}ERROR: nvcc not found. Please install CUDA toolkit.${NC}"
+    exit 1
+fi
+
+CUDA_VERSION=$(nvcc --version | grep "release" | sed -n 's/.*release \([0-9]*\.[0-9]*\).*/\1/p')
+echo "  CUDA version: $CUDA_VERSION"
+
+# Check Python
+if ! command -v python &> /dev/null; then
+    echo -e "${RED}ERROR: python not found.${NC}"
+    exit 1
+fi
+
+PYTHON_VERSION=$(python --version 2>&1 | sed -n 's/Python \([0-9]*\.[0-9]*\).*/\1/p')
+echo "  Python version: $PYTHON_VERSION"
+
+# Check PyTorch CUDA
+TORCH_CUDA=$(python -c "import torch; print(torch.cuda.is_available())" 2>/dev/null || echo "false")
+if [ "$TORCH_CUDA" != "True" ]; then
+    echo -e "${RED}ERROR: PyTorch CUDA not available.${NC}"
+    echo "Install with: pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121"
+    exit 1
+fi
+echo "  PyTorch CUDA: Available"
+
+# Check Mega-SAM submodule
+if [ ! -d "$MEGASAM_DIR" ]; then
+    echo -e "${RED}ERROR: Mega-SAM submodule not found at $MEGASAM_DIR${NC}"
+    echo "Initialize with: git submodule update --init --recursive"
+    exit 1
+fi
+echo "  Mega-SAM submodule: Found"
+
+# Check DROID weights (should already exist in submodule)
+if [ ! -f "$MEGASAM_DIR/checkpoints/megasam_final.pth" ]; then
+    echo -e "${YELLOW}WARNING: megasam_final.pth not found in checkpoints/${NC}"
+    echo "This checkpoint should be included in the submodule."
+fi
+
+echo -e "${GREEN}Prerequisites verified.${NC}"
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 2: Download Depth-Anything Checkpoint
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}Step 2: Downloading Depth-Anything checkpoint...${NC}"
+
+DEPTH_ANYTHING_CKPT="$DEPTH_ANYTHING_DIR/checkpoints/depth_anything_vitl14.pth"
+mkdir -p "$(dirname "$DEPTH_ANYTHING_CKPT")"
+
+if [ -f "$DEPTH_ANYTHING_CKPT" ]; then
+    echo "  Checkpoint already exists: $DEPTH_ANYTHING_CKPT"
+else
+    echo "  Downloading depth_anything_vitl14.pth (~1.3GB)..."
+    wget -q --show-progress -O "$DEPTH_ANYTHING_CKPT" \
+        "https://huggingface.co/spaces/LiheYoung/Depth-Anything/resolve/main/checkpoints/depth_anything_vitl14.pth"
+
+    if [ -f "$DEPTH_ANYTHING_CKPT" ]; then
+        echo -e "${GREEN}  Depth-Anything checkpoint downloaded.${NC}"
+    else
+        echo -e "${RED}  Failed to download Depth-Anything checkpoint.${NC}"
+        echo "  Manual download from: https://huggingface.co/spaces/LiheYoung/Depth-Anything"
+    fi
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 3: Download RAFT Checkpoint
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}Step 3: Downloading RAFT optical flow checkpoint...${NC}"
+
+RAFT_CKPT="$CVD_OPT_DIR/raft-things.pth"
+mkdir -p "$(dirname "$RAFT_CKPT")"
+
+if [ -f "$RAFT_CKPT" ]; then
+    echo "  Checkpoint already exists: $RAFT_CKPT"
+else
+    echo "  Downloading raft-things.pth..."
+    # RAFT checkpoint from Google Drive (may require gdown)
+    if command -v gdown &> /dev/null; then
+        gdown "https://drive.google.com/uc?id=1MqDajR89k-xLV0HIrmJ0k-n8ZpG6_NDA" -O "$RAFT_CKPT"
+    else
+        echo -e "${YELLOW}  gdown not installed. Installing...${NC}"
+        pip install gdown
+        gdown "https://drive.google.com/uc?id=1MqDajR89k-xLV0HIrmJ0k-n8ZpG6_NDA" -O "$RAFT_CKPT"
+    fi
+
+    if [ -f "$RAFT_CKPT" ]; then
+        echo -e "${GREEN}  RAFT checkpoint downloaded.${NC}"
+    else
+        echo -e "${YELLOW}  Could not download RAFT checkpoint automatically.${NC}"
+        echo "  Manual download from: https://drive.google.com/drive/folders/1sWDsfuZ3Up38EUQt7-JDTT1HcGHuJgvT"
+    fi
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 4: Compile lietorch CUDA Extensions
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}Step 4: Compiling lietorch CUDA extensions...${NC}"
+
+LIETORCH_DIR="$MEGASAM_DIR/base/thirdparty/lietorch"
+
+if [ -d "$LIETORCH_DIR" ]; then
+    cd "$LIETORCH_DIR"
+
+    # Check if already installed
+    if python -c "import lietorch" 2>/dev/null; then
+        echo "  lietorch already installed"
+    else
+        echo "  Building lietorch..."
+        pip install -e . 2>&1 | tail -5
+
+        # Verify installation
+        if python -c "import lietorch; print('lietorch:', lietorch.__file__)" 2>/dev/null; then
+            echo -e "${GREEN}  lietorch compiled successfully.${NC}"
+        else
+            echo -e "${RED}  lietorch compilation failed.${NC}"
+            echo "  Check CUDA version compatibility."
+            exit 1
+        fi
+    fi
+else
+    echo -e "${YELLOW}  lietorch directory not found at $LIETORCH_DIR${NC}"
+    echo "  Trying pip install..."
+    pip install lietorch || echo "lietorch may need manual installation"
+fi
+
+cd "$PROJECT_ROOT"
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 5: Compile DROID SLAM Extensions
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}Step 5: Compiling DROID SLAM extensions...${NC}"
+
+DROID_BASE_DIR="$MEGASAM_DIR/base"
+
+if [ -f "$DROID_BASE_DIR/setup.py" ]; then
+    cd "$DROID_BASE_DIR"
+
+    # Check if already installed
+    if python -c "import droid_backends" 2>/dev/null; then
+        echo "  DROID SLAM extensions already installed"
+    else
+        echo "  Building DROID SLAM extensions..."
+        pip install -e . 2>&1 | tail -5
+
+        # Verify installation
+        if python -c "import droid_backends; print('droid_backends loaded')" 2>/dev/null; then
+            echo -e "${GREEN}  DROID SLAM extensions compiled successfully.${NC}"
+        else
+            echo -e "${RED}  DROID SLAM compilation failed.${NC}"
+            exit 1
+        fi
+    fi
+else
+    echo -e "${RED}  DROID setup.py not found at $DROID_BASE_DIR${NC}"
+    exit 1
+fi
+
+cd "$PROJECT_ROOT"
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 6: Install Python Dependencies
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}Step 6: Installing Python dependencies...${NC}"
+
+# UniDepth
+if python -c "import unidepth" 2>/dev/null; then
+    echo "  unidepth already installed"
+else
+    echo "  Installing unidepth..."
+    pip install unidepth 2>&1 | tail -3
+fi
+
+# xformers (for UniDepth attention optimization)
+if python -c "import xformers" 2>/dev/null; then
+    echo "  xformers already installed"
+else
+    echo "  Installing xformers..."
+    pip install xformers 2>&1 | tail -3
+fi
+
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 7: Verification
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}Step 7: Verifying installation...${NC}"
+
+VERIFICATION_SCRIPT=$(cat << 'EOF'
+import sys
+
+checks = []
+
+# Check lietorch
+try:
+    import lietorch
+    checks.append(("lietorch", True, lietorch.__file__))
+except ImportError as e:
+    checks.append(("lietorch", False, str(e)))
+
+# Check DROID backends
+try:
+    import droid_backends
+    checks.append(("droid_backends", True, "loaded"))
+except ImportError as e:
+    checks.append(("droid_backends", False, str(e)))
+
+# Check unidepth
+try:
+    import unidepth
+    checks.append(("unidepth", True, "loaded"))
+except ImportError as e:
+    checks.append(("unidepth", False, str(e)))
+
+# Print results
+all_pass = True
+for name, success, info in checks:
+    status = "OK" if success else "FAIL"
+    print(f"  {name}: {status} ({info[:50]}...)" if len(info) > 50 else f"  {name}: {status} ({info})")
+    if not success:
+        all_pass = False
+
+sys.exit(0 if all_pass else 1)
+EOF
+)
+
+if python -c "$VERIFICATION_SCRIPT"; then
+    echo ""
+    echo -e "${GREEN}=========================================="
+    echo "Mega-SAM setup completed successfully!"
+    echo "==========================================${NC}"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Run tests: pytest tests/stages/test_video_processing_megasam.py -v"
+    echo "  2. Try Mega-SAM: python -c \\"
+    echo "       from backend.stages.video_processing import VideoProcessingStage"
+    echo "       stage = VideoProcessingStage({'pose_estimator': 'megasam'})"
+    echo "       print('Mega-SAM available:', stage._get_megasam_estimator().is_available())\""
+else
+    echo ""
+    echo -e "${RED}=========================================="
+    echo "Mega-SAM setup completed with warnings."
+    echo "Some components may not be fully functional."
+    echo "==========================================${NC}"
+    exit 1
+fi

--- a/tests/stages/test_video_processing_megasam.py
+++ b/tests/stages/test_video_processing_megasam.py
@@ -1,0 +1,495 @@
+"""Unit tests for Mega-SAM pose estimation integration.
+
+Tests cover:
+1. MegaSamResult dataclass
+2. MegaSamPoseEstimator availability checks
+3. SE3 to c2w conversion
+4. Intrinsics from FOV calculation
+5. Depth alignment logic
+6. Fallback validation
+7. VideoProcessingStage megasam integration
+"""
+
+import json
+import pytest
+import numpy as np
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+from dataclasses import asdict
+
+# Import the modules under test
+from backend.stages.video_processing import (
+    MegaSamResult,
+    MegaSamPoseEstimator,
+    MegaSamError,
+    VideoProcessingStage,
+    VideoProcessingResult,
+    MEGASAM_PATH,
+)
+
+
+# =============================================================================
+# MegaSamResult Tests
+# =============================================================================
+
+class TestMegaSamResult:
+    """Tests for MegaSamResult dataclass."""
+
+    def test_basic_creation(self):
+        """Test creating MegaSamResult with required fields."""
+        poses = np.eye(4)[np.newaxis]  # (1, 4, 4)
+        intrinsics = np.eye(3)
+
+        result = MegaSamResult(
+            poses=poses,
+            intrinsics=intrinsics,
+        )
+
+        assert result.poses.shape == (1, 4, 4)
+        assert result.intrinsics.shape == (3, 3)
+        assert result.depth_maps_dir is None
+        assert result.motion_prob_path is None
+        assert result.num_keyframes == 0
+        assert result.metrics == {}
+
+    def test_full_creation(self):
+        """Test creating MegaSamResult with all fields."""
+        poses = np.random.rand(10, 4, 4)
+        intrinsics = np.array([
+            [500, 0, 320],
+            [0, 500, 240],
+            [0, 0, 1]
+        ], dtype=np.float32)
+
+        result = MegaSamResult(
+            poses=poses,
+            intrinsics=intrinsics,
+            depth_maps_dir="/path/to/depths",
+            motion_prob_path="/path/to/motion.npy",
+            num_keyframes=8,
+            metrics={"median_fov": 60.0},
+        )
+
+        assert result.poses.shape == (10, 4, 4)
+        assert result.depth_maps_dir == "/path/to/depths"
+        assert result.motion_prob_path == "/path/to/motion.npy"
+        assert result.num_keyframes == 8
+        assert result.metrics["median_fov"] == 60.0
+
+
+# =============================================================================
+# MegaSamPoseEstimator Tests
+# =============================================================================
+
+class TestMegaSamPoseEstimator:
+    """Tests for MegaSamPoseEstimator class."""
+
+    def test_init_default_config(self):
+        """Test initialization with default config."""
+        estimator = MegaSamPoseEstimator()
+
+        assert estimator.opt_focal is True
+        assert estimator.max_frames == 300
+        assert estimator.disable_vis is True
+        assert estimator._megasam_estimator is None or estimator._path_added is False
+
+    def test_init_custom_config(self):
+        """Test initialization with custom config."""
+        config = {
+            "opt_focal": False,
+            "max_frames": 150,
+        }
+        estimator = MegaSamPoseEstimator(config)
+
+        assert estimator.opt_focal is False
+        assert estimator.max_frames == 150
+
+    def test_megasam_path_constant(self):
+        """Test MEGASAM_PATH points to correct location."""
+        assert "instant4d" in str(MEGASAM_PATH)
+        assert "mega-sam" in str(MEGASAM_PATH)
+
+    def test_droid_weights_path(self):
+        """Test DROID weights path is correctly defined."""
+        estimator = MegaSamPoseEstimator()
+        assert "megasam_final.pth" in str(estimator.DROID_WEIGHTS)
+        assert "checkpoints" in str(estimator.DROID_WEIGHTS)
+
+    @patch.object(MegaSamPoseEstimator, '_add_megasam_to_path')
+    def test_is_available_no_checkpoint(self, mock_add_path):
+        """Test is_available returns False when checkpoint missing."""
+        estimator = MegaSamPoseEstimator()
+
+        with patch.object(Path, 'exists', return_value=False):
+            estimator._available = None  # Reset cache
+            result = estimator.is_available()
+
+        assert result is False
+
+    def test_is_available_caches_result(self):
+        """Test is_available caches its result."""
+        estimator = MegaSamPoseEstimator()
+        estimator._available = True  # Pre-set cache
+
+        result = estimator.is_available()
+        assert result is True  # Returns cached value
+
+
+class TestSE3Conversion:
+    """Tests for SE3 to camera-to-world conversion."""
+
+    @pytest.mark.gpu
+    def test_se3_identity_conversion(self):
+        """Test SE3 identity converts to identity c2w."""
+        estimator = MegaSamPoseEstimator()
+
+        # Identity SE3: [0, 0, 0, 0, 0, 0, 1] (qw=1)
+        # Position: (0, 0, 0), Rotation: identity quaternion
+        identity_se3 = np.array([[0, 0, 0, 0, 0, 0, 1]], dtype=np.float32)
+
+        estimator._add_megasam_to_path()
+        c2w = estimator._se3_to_c2w(identity_se3)
+
+        expected = np.eye(4)
+        np.testing.assert_array_almost_equal(c2w[0], expected, decimal=5)
+
+    @pytest.mark.gpu
+    def test_se3_translation_conversion(self):
+        """Test SE3 with translation converts correctly."""
+        estimator = MegaSamPoseEstimator()
+
+        # SE3 with translation (1, 2, 3), identity rotation
+        se3 = np.array([[1, 2, 3, 0, 0, 0, 1]], dtype=np.float32)
+
+        estimator._add_megasam_to_path()
+        c2w = estimator._se3_to_c2w(se3)
+
+        # Translation should be negated (inv() effect on pose)
+        # The exact result depends on lietorch SE3 conventions
+        assert c2w.shape == (1, 4, 4)
+        assert c2w[0, 3, 3] == 1.0  # Homogeneous coordinate
+
+
+class TestIntrinsicsFromFOV:
+    """Tests for intrinsics computation from FOV."""
+
+    def test_fov_60_degrees(self):
+        """Test focal length from 60 degree FOV."""
+        # FOV = 60 degrees, width = 640
+        fov = 60.0
+        width = 640
+
+        focal = width / (2 * np.tan(np.radians(fov) / 2.0))
+
+        # For 60 degree FOV: f = w / (2 * tan(30)) = 640 / (2 * 0.577) ≈ 554
+        assert 550 < focal < 560
+
+    def test_fov_90_degrees(self):
+        """Test focal length from 90 degree FOV (wide angle)."""
+        fov = 90.0
+        width = 640
+
+        focal = width / (2 * np.tan(np.radians(fov) / 2.0))
+
+        # For 90 degree FOV: f = w / (2 * tan(45)) = 640 / (2 * 1) = 320
+        assert abs(focal - 320) < 1
+
+
+class TestDepthAlignment:
+    """Tests for depth alignment logic."""
+
+    def test_scale_shift_computation(self):
+        """Test scale/shift computation between mono and metric depth."""
+        # Create synthetic mono disparity and metric depth
+        mono_disp = np.random.rand(100, 100).astype(np.float32) * 0.1 + 0.01
+        metric_depth = 1.0 / (mono_disp * 2 + 0.5)  # Known relationship
+
+        gt_disp = 1.0 / (metric_depth + 1e-8)
+
+        # Compute scale/shift using median method
+        gt_disp_ms = gt_disp - np.median(gt_disp) + 1e-8
+        da_disp_ms = mono_disp - np.median(mono_disp) + 1e-8
+        scale = np.median(gt_disp_ms / da_disp_ms)
+        shift = np.median(gt_disp - scale * mono_disp)
+
+        # Verify reconstruction
+        reconstructed = scale * mono_disp + shift
+        error = np.abs(reconstructed - gt_disp).mean()
+        assert error < 0.1  # Should be close
+
+    def test_sky_handling(self):
+        """Test special handling for sky-dominated scenes."""
+        # Create disparity with 60% sky (very low disparity)
+        mono_disp = np.ones((100, 100), dtype=np.float32) * 0.005
+        mono_disp[60:, :] = 0.1  # Ground region
+
+        sky_ratio = np.sum(mono_disp < 0.01) / (mono_disp.shape[0] * mono_disp.shape[1])
+        assert sky_ratio > 0.5
+
+        # Non-sky mask should exclude sky
+        non_sky_mask = mono_disp > 0.01
+        assert np.sum(non_sky_mask) == 4000  # 40 * 100
+
+
+# =============================================================================
+# Validation Tests
+# =============================================================================
+
+class TestMegaSamValidation:
+    """Tests for Mega-SAM result validation."""
+
+    def test_validate_sufficient_keyframes(self):
+        """Test validation passes with sufficient keyframes."""
+        stage = VideoProcessingStage({"pose_estimator": "megasam"})
+        stage._video_metadata = {"width": 640, "height": 480}
+
+        result = MegaSamResult(
+            poses=np.eye(4)[np.newaxis].repeat(10, axis=0),
+            intrinsics=np.array([[500, 0, 320], [0, 500, 240], [0, 0, 1]]),
+            num_keyframes=8,
+        )
+
+        # Should not raise for 8 keyframes out of 10 frames
+        stage._validate_megasam_result(result, 10)
+
+    def test_validate_insufficient_keyframes(self):
+        """Test validation fails with insufficient keyframes."""
+        stage = VideoProcessingStage({"pose_estimator": "megasam"})
+        stage._video_metadata = {"width": 640, "height": 480}
+
+        result = MegaSamResult(
+            poses=np.eye(4)[np.newaxis].repeat(10, axis=0),
+            intrinsics=np.array([[500, 0, 320], [0, 500, 240], [0, 0, 1]]),
+            num_keyframes=3,  # Only 30%
+        )
+
+        with pytest.raises(MegaSamError, match="Too few keyframes"):
+            stage._validate_megasam_result(result, 10)
+
+    def test_validate_nan_poses(self):
+        """Test validation fails with NaN in poses."""
+        stage = VideoProcessingStage({"pose_estimator": "megasam"})
+        stage._video_metadata = {"width": 640, "height": 480}
+
+        poses = np.eye(4)[np.newaxis].repeat(10, axis=0)
+        poses[5, 0, 0] = np.nan  # Introduce NaN
+
+        result = MegaSamResult(
+            poses=poses,
+            intrinsics=np.array([[500, 0, 320], [0, 500, 240], [0, 0, 1]]),
+            num_keyframes=8,
+        )
+
+        with pytest.raises(MegaSamError, match="Invalid poses"):
+            stage._validate_megasam_result(result, 10)
+
+    def test_validate_unreasonable_focal_low(self):
+        """Test validation fails with too low focal length."""
+        stage = VideoProcessingStage({"pose_estimator": "megasam"})
+        stage._video_metadata = {"width": 640, "height": 480}
+
+        result = MegaSamResult(
+            poses=np.eye(4)[np.newaxis].repeat(10, axis=0),
+            intrinsics=np.array([[50, 0, 320], [0, 50, 240], [0, 0, 1]]),  # Too low
+            num_keyframes=8,
+        )
+
+        with pytest.raises(MegaSamError, match="Unreasonable focal length"):
+            stage._validate_megasam_result(result, 10)
+
+    def test_validate_unreasonable_focal_high(self):
+        """Test validation fails with too high focal length."""
+        stage = VideoProcessingStage({"pose_estimator": "megasam"})
+        stage._video_metadata = {"width": 640, "height": 480}
+
+        result = MegaSamResult(
+            poses=np.eye(4)[np.newaxis].repeat(10, axis=0),
+            intrinsics=np.array([[6000, 0, 320], [0, 6000, 240], [0, 0, 1]]),  # Too high
+            num_keyframes=8,
+        )
+
+        with pytest.raises(MegaSamError, match="Unreasonable focal length"):
+            stage._validate_megasam_result(result, 10)
+
+
+# =============================================================================
+# VideoProcessingStage Integration Tests
+# =============================================================================
+
+class TestVideoProcessingStageConfig:
+    """Tests for VideoProcessingStage configuration."""
+
+    def test_default_pose_estimator_is_megasam(self):
+        """Test that megasam is the default pose estimator."""
+        stage = VideoProcessingStage()
+        assert stage.pose_estimator == "megasam"
+
+    def test_explicit_megasam_config(self):
+        """Test explicit megasam configuration."""
+        stage = VideoProcessingStage({"pose_estimator": "megasam"})
+        assert stage.pose_estimator == "megasam"
+        assert "opt_focal" in stage.megasam_config
+        assert stage.megasam_config["opt_focal"] is True
+
+    def test_custom_megasam_focal_config(self):
+        """Test custom focal optimization config."""
+        stage = VideoProcessingStage({
+            "pose_estimator": "megasam",
+            "megasam_opt_focal": False,
+        })
+        assert stage.megasam_config["opt_focal"] is False
+
+    def test_hloc_config(self):
+        """Test hloc configuration still works."""
+        stage = VideoProcessingStage({"pose_estimator": "hloc"})
+        assert stage.pose_estimator == "hloc"
+
+    def test_dust3r_config(self):
+        """Test dust3r configuration still works."""
+        stage = VideoProcessingStage({"pose_estimator": "dust3r"})
+        assert stage.pose_estimator == "dust3r"
+
+
+class TestMegaSamFallback:
+    """Tests for Mega-SAM to hloc fallback behavior."""
+
+    @patch('backend.stages.video_processing.MegaSamPoseEstimator')
+    def test_fallback_on_megasam_unavailable(self, mock_estimator_class, tmp_path):
+        """Test fallback to hloc when Mega-SAM unavailable."""
+        # Setup mock estimator that's unavailable
+        mock_estimator = MagicMock()
+        mock_estimator.is_available.return_value = False
+        mock_estimator_class.return_value = mock_estimator
+
+        stage = VideoProcessingStage({"pose_estimator": "megasam"})
+
+        # _get_megasam_estimator should return the mock
+        stage._megasam_estimator = mock_estimator
+
+        # Calling _run_megasam_pipeline should raise MegaSamError
+        with pytest.raises(MegaSamError, match="not available"):
+            stage._run_megasam_pipeline(
+                frames_dir=tmp_path,
+                output_dir=tmp_path,
+                transforms_path=tmp_path / "transforms.json",
+            )
+
+
+# =============================================================================
+# Transforms.json Export Tests
+# =============================================================================
+
+class TestTransformsJsonExport:
+    """Tests for transforms.json export."""
+
+    def test_to_transforms_json_format(self, tmp_path):
+        """Test that exported JSON has correct format."""
+        estimator = MegaSamPoseEstimator()
+
+        # Create mock result
+        poses = np.eye(4)[np.newaxis].repeat(3, axis=0)
+        intrinsics = np.array([
+            [500, 0, 320],
+            [0, 500, 240],
+            [0, 0, 1]
+        ], dtype=np.float32)
+
+        result = MegaSamResult(
+            poses=poses,
+            intrinsics=intrinsics,
+            num_keyframes=3,
+        )
+
+        # Create mock frame paths
+        frame_paths = [
+            tmp_path / "0001.jpg",
+            tmp_path / "0002.jpg",
+            tmp_path / "0003.jpg",
+        ]
+        for p in frame_paths:
+            p.touch()
+
+        output_path = tmp_path / "transforms.json"
+        estimator.to_transforms_json(result, frame_paths, output_path, (640, 480))
+
+        # Verify JSON structure
+        with open(output_path) as f:
+            transforms = json.load(f)
+
+        assert transforms["camera_model"] == "OPENCV"
+        assert transforms["fl_x"] == 500.0
+        assert transforms["fl_y"] == 500.0
+        assert transforms["cx"] == 320.0
+        assert transforms["cy"] == 240.0
+        assert transforms["w"] == 640
+        assert transforms["h"] == 480
+        assert len(transforms["frames"]) == 3
+        assert "transform_matrix" in transforms["frames"][0]
+        assert len(transforms["frames"][0]["transform_matrix"]) == 4  # 4x4 matrix
+
+    def test_to_transforms_json_opengl_convention(self, tmp_path):
+        """Test that Y and Z are flipped for OpenGL convention."""
+        estimator = MegaSamPoseEstimator()
+
+        # Create pose with known Y and Z columns
+        pose = np.eye(4)
+        pose[:3, 1] = [0, 1, 0]  # Y column
+        pose[:3, 2] = [0, 0, 1]  # Z column
+        poses = pose[np.newaxis]
+
+        result = MegaSamResult(
+            poses=poses,
+            intrinsics=np.eye(3) * 500,
+            num_keyframes=1,
+        )
+
+        frame_paths = [tmp_path / "0001.jpg"]
+        frame_paths[0].touch()
+
+        output_path = tmp_path / "transforms.json"
+        estimator.to_transforms_json(result, frame_paths, output_path, (640, 480))
+
+        with open(output_path) as f:
+            transforms = json.load(f)
+
+        matrix = np.array(transforms["frames"][0]["transform_matrix"])
+
+        # Y and Z columns should be negated
+        np.testing.assert_array_almost_equal(matrix[:3, 1], [0, -1, 0])
+        np.testing.assert_array_almost_equal(matrix[:3, 2], [0, 0, -1])
+
+
+# =============================================================================
+# GPU Integration Tests (marked to skip on CPU-only systems)
+# =============================================================================
+
+@pytest.mark.gpu
+class TestMegaSamGPUIntegration:
+    """GPU-required integration tests for Mega-SAM."""
+
+    def test_lietorch_import(self):
+        """Test lietorch can be imported."""
+        estimator = MegaSamPoseEstimator()
+        estimator._add_megasam_to_path()
+
+        import lietorch
+        assert hasattr(lietorch, 'SE3')
+
+    def test_se3_batch_conversion(self):
+        """Test SE3 conversion with batch of poses."""
+        estimator = MegaSamPoseEstimator()
+        estimator._add_megasam_to_path()
+
+        # Create batch of SE3 poses
+        batch_size = 10
+        se3 = np.random.randn(batch_size, 7).astype(np.float32)
+        # Normalize quaternion part
+        se3[:, 3:] /= np.linalg.norm(se3[:, 3:], axis=1, keepdims=True)
+
+        c2w = estimator._se3_to_c2w(se3)
+
+        assert c2w.shape == (batch_size, 4, 4)
+        # All matrices should be valid (finite values)
+        assert np.isfinite(c2w).all()
+        # Last row should be [0, 0, 0, 1]
+        np.testing.assert_array_almost_equal(c2w[:, 3, :], [[0, 0, 0, 1]] * batch_size)


### PR DESCRIPTION
# Summary

- Add Mega-SAM as the primary pose estimator for Stage 1 (Video Processing), with automatic fallback to hloc/GLOMAP → DUSt3R
- Integrate Mega-SAM outputs (depth maps, motion probability) with Instant4DAdapter for improved 4D reconstruction initialization
- Create setup script and comprehensive test suite for Mega-SAM dependencies

## Changes

### New Files
- `backend/stages/video_processing.py` - Added `MegaSamPoseEstimator` class (~600 lines)
- `tests/stages/test_video_processing_megasam.py` - Unit & GPU tests
- `scripts/setup_megasam.sh` - Checkpoint downloads & CUDA compilation

### Modified Files
- `backend/adapters/instant4d.py` - Added depth/motion passthrough support
- `docs/ROADMAP.md` - Marked Step 3 as COMPLETED
- `docs/STATUS.md` - Updated with Step 3 completion details
- `docs/ARCHITECTURE.md` - Updated current state diagrams
- `docs/SETUP.md` - Added Mega-SAM setup instructions

## Mega-SAM Pipeline

UniDepth (metric depth + FOV)
↓
Depth-Anything (mono disparity)
↓
Depth Alignment (scale/shift calibration)
↓
DROID SLAM (camera tracking with SE3 poses)
↓
SE3 → 4x4 c2w (OpenGL convention)



## Fallback System

| Trigger | Action |
|---------|--------|
| Checkpoint not found | Fall back to hloc |
| lietorch import fails | Fall back to hloc |
| Keyframe ratio < 50% | Fall back to hloc |
| NaN/Inf poses | Fall back to hloc |
| CUDA OOM | Fall back to hloc |
| Unreasonable intrinsics | Fall back to hloc |

## Test Plan

- [ ] Run `bash scripts/setup_megasam.sh` on GPU server
- [ ] Run `pytest tests/stages/test_video_processing_megasam.py -v`
- [ ] Run `pytest tests/stages/test_video_processing_megasam.py -v -m gpu` (GPU tests)
- [ ] Test end-to-end with sample video (5-10 seconds)
- [ ] Verify Mega-SAM → hloc fallback triggers correctly