### PR TITLE
feat: add temporal replay video and fix video codec fallback

### DIFF
--- a/backend/adapters/instant4d.py
+++ b/backend/adapters/instant4d.py
@@ -80,6 +80,16 @@ class Instant4DOptions:
     opacity_threshold: float = 0.01
     """Minimum opacity for including Gaussians in export."""
 
+    # Video rendering
+    replay_num_frames: int = 120
+    """Number of frames in temporal replay video (120 = 4 seconds at 30fps)."""
+
+    replay_fps: int = 30
+    """Frame rate for temporal replay video."""
+
+    replay_wobble_factor: float = 0.05
+    """Camera wobble amplitude for temporal replay (0 = fixed viewpoint)."""
+
 
 @dataclass
 class Instant4DResult:
@@ -803,7 +813,10 @@ class Instant4DAdapter:
 
         report(0.97, "Phase 4b: Rendering temporal replay video")
         replay_path = self.render_temporal_replay_video(
-            preview_dir, num_frames=120, fps=30, wobble_factor=0.05,
+            preview_dir,
+            num_frames=options.replay_num_frames,
+            fps=options.replay_fps,
+            wobble_factor=options.replay_wobble_factor,
         )
         if replay_path:
             result.temporal_replay_path = replay_path

--- a/tests/adapters/test_instant4d_adapter.py
+++ b/tests/adapters/test_instant4d_adapter.py
@@ -764,3 +764,31 @@ class TestTemporalReplay:
         result = Instant4DResult(model_path="/tmp/test")
         assert hasattr(result, "temporal_replay_path")
         assert result.temporal_replay_path is None
+
+    def test_temporal_replay_handles_render_exception(self, tmp_path):
+        """render_temporal_replay_video returns None when rendering raises."""
+        from unittest.mock import MagicMock
+        from backend.adapters.instant4d import Instant4DAdapter
+
+        try:
+            adapter = Instant4DAdapter()
+            # Set up mocks so the early-exit guards pass
+            adapter._scene = MagicMock()
+            adapter._gaussian_model = MagicMock()
+            adapter._pipe_params = MagicMock()
+            # Make the scene method raise
+            adapter._scene.render_temporal_replay.side_effect = RuntimeError("GPU OOM")
+
+            result = adapter.render_temporal_replay_video(str(tmp_path / "output"))
+            assert result is None
+        except ImportError as e:
+            pytest.skip(f"Instant4D not available: {e}")
+
+    def test_replay_options_defaults(self):
+        """Instant4DOptions has configurable replay parameters with correct defaults."""
+        from backend.adapters.instant4d import Instant4DOptions
+
+        opts = Instant4DOptions()
+        assert opts.replay_num_frames == 120
+        assert opts.replay_fps == 30
+        assert opts.replay_wobble_factor == 0.05


### PR DESCRIPTION
## Summary
- Add temporal replay video rendering that advances through time (0→3s) while gently wobbling the camera, showing the full 4D scene evolution
- Replace hardcoded `avc1` video codec with cross-platform fallback chain (`avc1` → `mp4v` → `XVID`) via `Scene._create_video_writer()`
- Disable aggressive size-based pruning for 5K-iteration training (`opacity_reset_interval` 3000→30000) — prevents PSNR collapse at iteration 3200
- Enable temporal spherical harmonics (`eval_shfs_4d=True`, `sh_degree_t=2`)

## Files changed
- `instant4d/scene/__init__.py` — `_create_video_writer()`, codec fix in `render_evaluate_sora`, new `render_temporal_replay()`
- `backend/adapters/instant4d.py` — `render_temporal_replay_video()`, pipeline wiring, `temporal_replay_path` on result, `opacity_reset_interval=30000`
- `tests/adapters/test_instant4d_adapter.py` — `TestTemporalReplay` class

## Test plan
- [ ] `git pull` on Colab, run full pipeline from scratch
- [ ] PSNR should climb steadily (no cliff at iter 3200)
- [ ] `preview/test/temporal_replay.mp4` shows scene evolving over time
- [ ] Wobble diagnostic videos still render (codec fallback works)
- [ ] `pytest tests/adapters/test_instant4d_adapter.py` passes locally